### PR TITLE
chore: upgrade onnxruntime-migraphx to 1.24.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,13 @@ Do not attempt to switch to ROCMExecutionProvider — it will fail with ABI
 errors against ROCm 7.x and is no longer maintained by AMD. The only
 alternative is CPUExecutionProvider, which works but is significantly slower.
 
+MIGraphX compiled model caching (`migraphx_save_compiled_model` provider
+option) exists in upstream ORT source but is NOT compiled into AMD's
+`onnxruntime-migraphx` builds (tested 1.23.2 and 1.24.2). The option is
+silently rejected, causing fallback to CPU. Do not attempt to use it.
+The 3-minute startup compile is currently unavoidable without building
+ORT from source with the cache flag enabled.
+
 ## Known issues
 - Streaming responses are audited post-hoc (dual-path accumulation) but invalid citations cannot be stripped in-flight — logged as errors instead
 - LLM phrasing variance: negative finding classifier depends on recognizable negation patterns before the ⚠️ marker — when the model phrases differently, classification may vary between runs

--- a/Containerfile.rocm
+++ b/Containerfile.rocm
@@ -26,7 +26,7 @@ WORKDIR /app
 RUN pip install --no-cache-dir --break-system-packages . && \
     pip uninstall -y --break-system-packages onnxruntime && \
     pip install --no-cache-dir --break-system-packages \
-        onnxruntime_migraphx==1.23.2 \
+        onnxruntime_migraphx==1.24.2 \
         -f https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.1/
 
 # Pre-download ONNX models so first request isn't slow.


### PR DESCRIPTION
## Summary
- Upgrade onnxruntime-migraphx from 1.23.2 to 1.24.2 (latest from AMD ROCm 7.2.1 repo)
- No behavioral changes — MIGraphX compile time unchanged (~3 min on gfx1151)
- Investigated compiled model caching — not available in AMD's builds, documented in CLAUDE.md

## Why not model caching?
The `migraphx_save_compiled_model` provider option exists in upstream ORT source
but AMD does not compile it into their `onnxruntime-migraphx` package. Both 1.23.2
and 1.24.2 silently reject the option and fall back to CPU. Eliminating the 3-min
startup compile requires building ORT from source.

## Test plan
- [x] 126 tests pass
- [x] Container builds successfully with 1.24.2
- [x] MIGraphXExecutionProvider active (not CPU fallback)
- [x] Startup time: 3m10s (same as 1.23.2)
- [x] Embedding requests succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified platform compatibility notes regarding MIGraphX startup behavior and performance considerations on ROCm systems.

* **Chores**
  * Updated ONNX Runtime MIGraphX dependency to version 1.24.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->