### PR TITLE
chore: update onnxruntime-migraphx to 1.24.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Two variants are published, both UBI9 Python 3.11, models pre-downloaded, non-ro
 | Variant | Tag | Containerfile | ONNX Runtime package | Base | GPU support |
 |---------|-----|---------------|---------------------|------|-------------|
 | CPU | `ghcr.io/aclater/ragpipe:main` | `Containerfile` | `onnxruntime` | UBI9 Python 3.11 | None (CPU only) |
-| ROCm | `ghcr.io/aclater/ragpipe:main-rocm` | `Containerfile.rocm` | `onnxruntime-migraphx` 1.23.2 (from AMD repo) | rocm/dev-ubuntu-24.04:7.2.1 | MIGraphXExecutionProvider |
+| ROCm | `ghcr.io/aclater/ragpipe:main-rocm` | `Containerfile.rocm` | `onnxruntime-migraphx` 1.24.2 (from AMD repo) | rocm/dev-ubuntu-24.04:7.2.1 | MIGraphXExecutionProvider |
 
 ```bash
 # CPU variant

--- a/Containerfile.rocm
+++ b/Containerfile.rocm
@@ -26,7 +26,7 @@ WORKDIR /app
 RUN pip install --no-cache-dir --break-system-packages . && \
     pip uninstall -y --break-system-packages onnxruntime && \
     pip install --no-cache-dir --break-system-packages \
-        onnxruntime_migraphx==1.23.2 \
+        onnxruntime_migraphx==1.24.2 \
         -f https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.1/
 
 # Pre-download ONNX models so first request isn't slow.


### PR DESCRIPTION
## Summary

Bump onnxruntime-migraphx from 1.23.2 to 1.24.2 in Containerfile.rocm. Also updates CLAUDE.md container table.

## Verified

- PyPI: 1.24.2 is current stable
- ROCm 7.2.1 wheel: confirmed available at AMD repo