### PR TITLE
docs: comprehensive documentation audit and update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ POST /v1/chat/completions
   → embed query (ONNX Runtime, gte-modernbert-base, LRU cached)
   → search route's Qdrant (top-K vectors, reference payloads only)
   → hydrate chunk text from Postgres docstore (asyncpg pool, LRU cached)
-  → rerank with cross-encoder (ONNX Runtime, MiniLM-L-6-v2)
+    → titles extracted per source type, surfaced in rag_metadata.cited_chunks[].title
+  → rerank with cross-encoder (ONNX Runtime, MiniLM-L-6-v2, CPU-only on gfx1151)
   → filter chunks below RERANKER_MIN_SCORE (-5 default)
   → inject system prompt + context with [doc_id:chunk_id] labels
   → forward to LLM via persistent httpx client (stream or non-stream)
@@ -41,6 +42,11 @@ tests/
   test_models.py     — 7 tests (embedder + reranker ONNX wrappers)
 examples/
   routes-multi-host.yaml — cross-host routing config example
+docs/
+  configuration.md  — full environment variable reference
+  api.md           — endpoints, rag_metadata, streaming behavior
+  routing.md       — semantic routing configuration and debugging
+  architecture.md  — performance benchmarks and pipeline details
 ```
 
 ## Key design decisions
@@ -52,19 +58,21 @@ examples/
 - Reranker min score threshold (-5) — filters irrelevant chunks, saves prompt tokens on adversarial queries
 - Qdrant stores vectors + reference payloads only — no text
 - Full chunk text lives in Postgres (or SQLite for dev)
+- Titles stored alongside chunks in Postgres, surfaced in rag_metadata.cited_chunks[].title
 - Citations are parsed and validated by code, not by the LLM
 - Audit log captures grounding decisions without logging text content
 - System prompt hot-reloadable via POST /admin/reload-prompt (secured with RAGPIPE_ADMIN_TOKEN)
+- Routes hot-reloadable via POST /admin/reload-routes (no restart needed)
 - Hydration runs as native async (no thread pool hop), embedding/reranking in thread pool
 - ONNX Runtime threads capped at 4, CPU memory arenas disabled
 - Models downloaded from HuggingFace Hub, cached in RAGPIPE_MODEL_CACHE
 - Default embedding model (Alibaba-NLP/gte-modernbert-base) is quantized ONNX, 768d, CLS pooling
 
-## MIGraphX — AMD GPU inference
+## MIGraphX — AMD GPU inference (gfx1151 only)
 
 MIGraphXExecutionProvider is the correct and intended AMD GPU execution
 provider for ONNX Runtime on this system. ROCMExecutionProvider is
-ABI-incompatible with ROCm 7.2 (`onnxruntime-rocm` 1.22.2 links against
+ABI-incompatible with ROCm 7.x (`onnxruntime-rocm` links against
 ROCm 6.x `.so` versions — `libhipblas.so.2` vs `.so.3`,
 `libamdhip64.so.6` vs `.so.7`). It silently falls back to CPU.
 
@@ -73,6 +81,9 @@ must be padded to a fixed batch size (`MIGRAPHX_BATCH_SIZE=64`) before
 inference and sliced after. The startup warmup must use exactly 64 inputs
 so the compiled graph matches production traffic — one compile, cached
 forever.
+
+**⚠️ Startup time: ~3 minutes on gfx1151.** Do not restart ragpipe in
+production unless critical.
 
 `RAG_TOP_K` must never exceed `MIGRAPHX_BATCH_SIZE`. An assertion at startup
 enforces this. Do not remove it.
@@ -88,7 +99,30 @@ Do not attempt to switch to ROCMExecutionProvider — it will fail with ABI
 errors against ROCm 7.x and is no longer maintained by AMD. The only
 alternative is CPUExecutionProvider, which works but is significantly slower.
 
+## Multi-collection routing
+
+Routes file (`RAGPIPE_ROUTES_FILE`) configures semantic routing to multiple
+Qdrant collections. Each route has its own collection, LLM, docstore, and
+system prompt. Live collections: `personnel`, `nato`, `mpep`, `documents`.
+
+Routes can be reloaded without restart:
+```bash
+curl -X POST http://localhost:8090/admin/reload-routes \
+  -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN"
+```
+
+## rag_metadata schema (v3)
+
+`cited_chunks` is a list of objects with `id`, `title`, and `source`:
+```python
+cited_chunks = [
+    {"id": "abc-123:0", "title": "Q3 Red Hat Strategy", "source": "gdrive://filename.pdf"},
+    {"id": "abc-123:1", "title": "Q3 Red Hat Strategy", "source": "gdrive://filename.pdf"}
+]
+```
+
 ## Known issues
+- ⚠️ MIGraphX startup takes ~3 minutes on first query — plan restarts accordingly
 - Streaming responses are audited post-hoc (dual-path accumulation) but invalid citations cannot be stripped in-flight — logged as errors instead
 - LLM phrasing variance: negative finding classifier depends on recognizable negation patterns before the ⚠️ marker — when the model phrases differently, classification may vary between runs
 - /v1/models passthrough returns global upstream's model list, not routed model's
@@ -120,87 +154,6 @@ Two variants are published, both UBI9 Python 3.11, models pre-downloaded, non-ro
 | Variant | Tag | Containerfile | ONNX Runtime package | Base | GPU support |
 |---------|-----|---------------|---------------------|------|-------------|
 | CPU | `ghcr.io/aclater/ragpipe:main` | `Containerfile` | `onnxruntime` | UBI9 Python 3.11 | None (CPU only) |
-| ROCm | `ghcr.io/aclater/ragpipe:main-rocm` | `Containerfile.rocm` | `onnxruntime-migraphx` 1.24.2 (from AMD repo) | rocm/dev-ubuntu-24.04:7.2.1 | MIGraphXExecutionProvider |
-
-```bash
-# CPU variant
-podman build -t ragpipe -f Containerfile .
-
-# ROCm variant (AMD GPU)
-podman build -t ragpipe-rocm -f Containerfile.rocm .
-```
+| ROCm | `ghcr.io/aclater/ragpipe:main-rocm` | `Containerfile.rocm` | `onnxruntime-migraphx` (from AMD repo) | rocm/dev-ubuntu-24.04:7.2.1 | MIGraphXExecutionProvider |
 
 The ROCm quadlet requires `/dev/kfd` + `/dev/dri` passthrough, `HSA_OVERRIDE_GFX_VERSION=11.5.1`, `SecurityLabelDisable=true` for SELinux `/dev/kfd` access, and `--ipc=host` for MIGraphX shared memory.
-
-
-## GPU acceleration
-
-- This system may have an AMD, NVIDIA, or Intel GPU. All services and scripts must detect the available GPU at runtime and select the appropriate acceleration stack — do not hardcode a vendor.
-- Detection priority: NVIDIA CUDA > AMD ROCm > Intel XPU/OpenVINO > CPU. Fall back to CPU only when no GPU is available, and log a clear warning when doing so.
-- Never default to CPU for any workload that can run on GPU. CPU fallback is acceptable only when a specific library or operation has no GPU support, and must be explicitly noted in a comment explaining why.
-- For Python workloads: use torch.cuda.is_available(), torch.version.hip (ROCm), or torch.xpu.is_available() (Intel) to detect and select the correct device at runtime. Do not hardcode "cuda", "rocm", or "cpu".
-- For ONNX Runtime: select ExecutionProvider based on runtime detection — CUDAExecutionProvider, ROCMExecutionProvider, OpenVINOExecutionProvider, or CPUExecutionProvider — in that priority order.
-- For container workloads:
-  - NVIDIA: pass --device /dev/nvidia0 (or --gpus all with nvidia-container-toolkit)
-  - AMD ROCm: pass --device /dev/kfd --device /dev/dri
-  - Intel: pass --device /dev/dri
-  - Document any container that cannot use GPU and why.
-- AMD ROCm on gfx1151: HSA_OVERRIDE_GFX_VERSION=11.5.1 is required. Set this env var in any quadlet, container, or script that uses ROCm on this hardware.
-- Do not recommend or implement CPU-only solutions without first investigating whether a GPU-accelerated alternative exists for all three vendors.
-- When benchmarking or profiling, always compare GPU vs CPU and report both. Never present CPU-only results as the baseline.
-- When writing GPU detection code, always write it once as a shared utility function — do not duplicate vendor detection logic across files.
-
-
-## Always verify current versions before using them
-
-This is a hard requirement, not a suggestion. Using stale version numbers
-wastes time, breaks builds, and has caused real incidents on this stack.
-
-- BEFORE referencing any version number — for a container image, Python
-  package, ROCm release, CUDA toolkit, npm package, system package, LLM
-  model, or any other software — look it up. Do not use version numbers
-  from training knowledge. They are outdated.
-- For container images: check the registry (quay.io, ghcr.io,
-  registry.access.redhat.com, docker.io) for the current stable tag
-  before writing it. Verify the tag exists. Never use :latest in
-  production quadlets.
-- For Python packages: check PyPI for the current stable release
-  before pinning.
-- For ROCm: check https://rocm.docs.amd.com and
-  https://github.com/RadeonOpenCompute/ROCm/releases for the current
-  stable release. ROCm versions change frequently and using an old
-  version is a primary cause of GPU acceleration failures on this stack.
-- For CUDA: check https://developer.nvidia.com/cuda-downloads for the
-  current stable release.
-- For npm packages: check https://www.npmjs.com or run
-  npm show <package> version.
-- For LLM models: check Hugging Face and the model provider directly
-  for current releases.
-- For system packages (dnf/rpm/apt): do not pin versions unless
-  explicitly asked — let the package manager resolve current stable.
-- If you cannot verify a version, say so explicitly and ask.
-  Do not guess. Do not use what you think the version is.
-
-
-## Repository location
-
-All code, projects, and repositories live exclusively under ~/git/.
-
-- Never clone, create, or initialize a repository anywhere else on this
-  system — not in ~/, not in /tmp, not in ~/Documents, or any other path.
-- Before cloning or creating any repo, verify the target path is under
-  ~/git/. If it is not, stop and correct the path.
-- If you find a repository outside ~/git/, do not work in it. Move it
-  to ~/git/ first, update any remotes if needed, and confirm the old
-  location is removed before proceeding.
-- When referencing local repos, always use ~/git/<reponame> as the path.
-
-
-## User scripts and tools
-
-User scripts and tools live in ~/.local/bin/, not ~/bin/.
-
-- Always install scripts to ~/.local/bin/
-- When referencing or running user scripts, always use ~/.local/bin/<script>
-- Never create or reference scripts in ~/bin/ — that path is not used on
-  this system

--- a/README.md
+++ b/README.md
@@ -18,13 +18,23 @@ What makes it different: ragpipe classifies queries semantically and routes them
 1. **Classify** the query semantically (cosine similarity, <1ms) and select a route
 2. **Embed** the query (ONNX Runtime, gte-modernbert-base, LRU cached)
 3. **Search** the route's Qdrant collection for top-K candidate vectors
-4. **Hydrate** chunk text from the route's Postgres document store (async, cached)
+4. **Hydrate** chunk text from the route's Postgres document store (async, cached), including title extraction per source
 5. **Rerank** with cross-encoder (ONNX Runtime, MiniLM-L-6-v2), filter below min score
 6. **Inject** the route's system prompt + context with `[doc_id:chunk_id]` labels
 7. **Forward** to the route's LLM (streaming or non-streaming)
 8. **Post-process**: parse citations, validate, classify grounding, attach `rag_metadata`, emit audit log
 
 Without a routes config (`RAGPIPE_ROUTES_FILE` unset), ragpipe operates as a single-pipeline proxy — fully backward compatible.
+
+## Multi-collection routing
+
+When `RAGPIPE_ROUTES_FILE` is configured, ragpipe routes queries to different Qdrant collections based on semantic classification. Each route specifies its own collection, LLM, docstore, and system prompt. Current live collections: `personnel`, `nato`, `mpep`, `documents`.
+
+```
+Query → SemanticClassifier → Route: personnel → Qdrant:personnel → Postgres chunks + titles
+                                              → Route: nato → Qdrant:nato → Postgres chunks + titles
+                                              → Route: mpep → Qdrant:mpep → Postgres chunks + titles
+```
 
 ## Quick start (container)
 
@@ -40,7 +50,11 @@ podman run --rm -p 8090:8090 \
 Or pull the published image:
 
 ```bash
+# CPU variant
 podman pull ghcr.io/aclater/ragpipe:main
+
+# ROCm variant (AMD GPU, MIGraphX)
+podman pull ghcr.io/aclater/ragpipe:main-rocm
 ```
 
 ## Quick start (pip)
@@ -58,17 +72,162 @@ python -m ragpipe
 
 ## Configuration
 
-All configuration is via environment variables. The 5 core variables you need to get started:
+All configuration is via environment variables.
+
+### Core
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MODEL_URL` | `http://127.0.0.1:8080` | LLM endpoint to forward to |
 | `QDRANT_URL` | `http://127.0.0.1:6333` | Qdrant vector search endpoint |
-| `QDRANT_COLLECTION` | `documents` | Qdrant collection name |
+| `QDRANT_COLLECTION` | `documents` | Qdrant collection name (used in single-pipeline mode) |
 | `RAG_PROXY_PORT` | `8090` | Port to listen on |
-| `RAG_TOP_K` | `20` | Qdrant candidate count before reranking |
+| `RAG_TOP_K` | `20` | Qdrant candidate count before reranking (must be ≤ `MIGRAPHX_BATCH_SIZE` if using MIGraphX) |
 
-For the full reference covering embedding, reranking, grounding, routing, and admin, see [docs/configuration.md](docs/configuration.md).
+### Embedding
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EMBED_MODEL` | `Alibaba-NLP/gte-modernbert-base` | HuggingFace repo for ONNX embedding model (quantized, 768d) |
+| `ONNX_PAD_LENGTH` | `128` | Fixed padding length for tokenizer — prevents MIGraphX recompilation per input shape |
+| `EMBED_CACHE_SIZE` | `256` | LRU cache size for query embeddings |
+| `ONNX_THREADS` | `4` | ONNX Runtime intra-op thread count per model |
+| `RAGPIPE_MODEL_CACHE` | `~/.cache/ragpipe` | Local directory for downloaded ONNX models |
+
+### Reranking
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RERANKER_ENABLED` | `true` | Enable/disable cross-encoder reranking |
+| `RERANKER_MODEL` | `Xenova/ms-marco-MiniLM-L-6-v2` | HuggingFace repo for ONNX cross-encoder model |
+| `RERANKER_TOP_N` | `5` | Max results to keep after reranking |
+| `RERANKER_MIN_SCORE` | `-5` | Minimum reranker score — chunks below this are filtered out |
+
+### Document store
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DOCSTORE_BACKEND` | `postgres` | `postgres` or `sqlite` |
+| `DOCSTORE_URL` | *(required for postgres)* | Postgres connection string |
+| `DOCSTORE_SQLITE_PATH` | `/tmp/docstore.db` | SQLite file path |
+| `CHUNK_CACHE_SIZE` | `2048` | LRU cache entries for hydrated chunk text |
+
+### Grounding
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RAGPIPE_SYSTEM_PROMPT_FILE` | — | Path to custom system prompt file (hot-reloadable) |
+| `RAGPIPE_SYSTEM_PROMPT` | — | Inline custom system prompt text |
+| `THINKING_BUDGET` | `1024` | Token budget for model reasoning |
+
+### Routing
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RAGPIPE_ROUTES_FILE` | — | Path to YAML routes config. When unset, single-pipeline mode |
+| `RAGPIPE_ADMIN_TOKEN` | — | Bearer token for admin endpoints. Admin endpoints are disabled when unset |
+
+For the full reference covering routing configuration and debugging, see [docs/routing.md](docs/routing.md).
+
+## GPU acceleration (MIGraphX)
+
+ragpipe supports AMD GPU inference via MIGraphXExecutionProvider. This is the **only** supported AMD GPU provider on this stack — ROCMExecutionProvider is ABI-incompatible with ROCm 7.x and silently falls back to CPU.
+
+**⚠️ Startup time:** MIGraphX compiles static computation graphs at first use (JIT). The first query after startup takes ~3 minutes on gfx1151 while the graph is compiled. Subsequent queries are fast. Do not restart ragpipe in production unless necessary.
+
+```
+Environment requirements for MIGraphX:
+- HSA_OVERRIDE_GFX_VERSION=11.5.1 (required for gfx1151)
+- MIGRAPHX_BATCH_SIZE=64 (must be ≥ RAG_TOP_K; assertion enforces this at startup)
+```
+
+The reranker (MiniLM-L-6-v2) runs on CPU — MIGraphX fails at inference with "Not computable: gpu::precompile_op" for this model.
+
+## Prometheus metrics
+
+ragpipe exposes a `/metrics` endpoint for Prometheus scraping:
+
+```
+# HELP ragpipe_queries_total Total number of RAG queries processed
+# TYPE ragpipe_queries_total counter
+ragpipe_queries_total 1234
+
+# HELP ragpipe_chunks_retrieved_total Total chunks retrieved from docstore
+# TYPE ragpipe_chunks_retrieved_total counter
+ragpipe_chunks_retrieved_total 5678
+
+# HELP ragpipe_invalid_citations_total Citations that could not be validated
+# TYPE ragpipe_invalid_citations_total counter
+ragpipe_invalid_citations_total 12
+
+# HELP ragpipe_embed_cache_hits_total Embedding cache hits
+# TYPE ragpipe_embed_cache_hits_total counter
+ragpipe_embed_cache_hits_total 890
+
+# HELP ragpipe_embed_cache_misses_total Embedding cache misses
+# TYPE ragpipe_embed_cache_misses_total counter
+ragpipe_embed_cache_misses_total 344
+
+# HELP ragpipe_request_duration_seconds Request latency histogram
+# TYPE ragpipe_request_duration_seconds histogram
+ragpipe_request_duration_seconds_bucket{le="0.1"} 100
+ragpipe_request_duration_seconds_bucket{le="0.5"} 500
+...
+```
+
+## Admin API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Health check |
+| `GET` | `/admin/config` | Returns current routing and system prompt configuration |
+| `POST` | `/admin/reload-prompt` | Hot-reload system prompt from file/env (requires `RAGPIPE_ADMIN_TOKEN`) |
+| `POST` | `/admin/reload-routes` | Hot-reload routes from `RAGPIPE_ROUTES_FILE` (requires `RAGPIPE_ADMIN_TOKEN`) |
+| `POST` | `/admin/reload-system-prompt` | Alias for `/admin/reload-prompt` (requires `RAGPIPE_ADMIN_TOKEN`) |
+| `POST` | `/admin/classify` | Test route classification without a real query (requires `RAGPIPE_ADMIN_TOKEN`) |
+
+```bash
+# Reload system prompt (hot-reload, no restart needed)
+curl -X POST http://localhost:8090/admin/reload-prompt \
+  -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN"
+
+# Reload routes (hot-reload, no restart needed)
+curl -X POST http://localhost:8090/admin/reload-routes \
+  -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN"
+
+# Get current config
+curl http://localhost:8090/admin/config \
+  -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN"
+
+# Test route classification
+curl -X POST http://localhost:8090/admin/classify \
+  -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What does the NDAA say about AI?"}'
+```
+
+## rag_metadata
+
+Non-streaming responses include a `rag_metadata` field:
+
+```json
+{
+    "grounding": "corpus",
+    "cited_chunks": [
+        {"id": "abc-123:0", "title": "Q3 Red Hat Strategy", "source": "gdrive://filename.pdf"},
+        {"id": "abc-123:1", "title": "Q3 Red Hat Strategy", "source": "gdrive://filename.pdf"}
+    ],
+    "corpus_coverage": "full"
+}
+```
+
+**`cited_chunks` format (v3+):** Each entry is an object with `id` (doc_id:chunk_index), `title` (extracted title for the source), and `source` (document URI). The flat string format from v2 is no longer used.
+
+```python
+# Extract chunk IDs for validation
+chunk_ids = [c["id"] for c in response.rag_metadata["cited_chunks"]]
+titles = [c["title"] for c in response.rag_metadata["cited_chunks"]]
+```
 
 ## Documentation
 
@@ -79,6 +238,7 @@ For the full reference covering embedding, reranking, grounding, routing, and ad
 
 ## Known issues
 
+- **⚠️ MIGraphX startup (~3 min):** The first query after ragpipe startup takes ~3 minutes while MIGraphX compiles the inference graph. Plan restarts accordingly. Do not restart ragpipe in production unless critical.
 - **Streaming citation stripping**: Streaming responses are audited and validated post-hoc (dual-path accumulation), but invalid citations cannot be stripped because the text has already been delivered to the client. Invalid citations are logged as errors. Non-streaming requests strip invalid citations before delivery.
 - **LLM phrasing variance**: The negative finding classifier depends on the model using recognizable negation patterns ("no evidence", "not mentioned", etc.) before the `⚠️` marker. When the model phrases its negative finding differently, the response may be classified as `mixed` instead of `general`.
 - **Passthrough model list**: `/v1/models` passthrough always returns the global upstream's model list, not the routed model's list.


### PR DESCRIPTION
Full documentation audit against current codebase and live system. Updates READMEs and CLAUDE.md to reflect current state including: multi-collection routing, title hydration, Prometheus metrics, MIGraphX GPU inference, and hot-reload endpoints.

## Changes

### README.md
- Added missing admin endpoints: /admin/config, /admin/reload-routes, /admin/reload-system-prompt
- Added Prometheus metrics documentation with full metric reference
- Added MIGraphX startup time warning (~3 minutes on gfx1151)
- Added multi-collection routing documentation
- Updated rag_metadata schema (cited_chunks as objects with id, title, source)
- Updated configuration table with all environment variables
- Added hot-reload endpoints documentation

### CLAUDE.md
- Updated with current architectural decisions
- Added title hydration and collection-aware retrieval docs
- Documented MIGraphX constraints