### PR TITLE
fix(ragpipe): log malformed SSE chunks at debug level (fixes #22)

### DIFF
--- a/ragpipe/app.py
+++ b/ragpipe/app.py
@@ -869,7 +869,7 @@ async def chat_completions(request: Request):
                         if text:
                             accumulated_content.append(text)
                     except json.JSONDecodeError:
-                        pass
+                        log.debug("Skipping non-JSON SSE line: %s", raw[:50])
                     yield raw + "\n\n"
 
         async def validate_after_stream(response: StreamingResponse) -> StreamingResponse:


### PR DESCRIPTION
Closes #22

## Problem
The SSE stream handler in `app.py:871` silently swallowed `json.JSONDecodeError` with a bare `pass`. Malformed upstream chunks were silently dropped with no visibility.

## Solution
Replaced `pass` with `log.debug(\"Skipping non-JSON SSE line: %s\", raw[:50])`. This surfaces malformed chunks at debug level without flooding logs during normal operation (keepalive pings are already handled by the earlier `if not raw.startswith(\"data: \")` guard).

## Testing
- 142 tests passed before and after the change
- `ruff check .` and `ruff format --check .` both pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-JSON data in Server-Sent Events (SSE) streaming responses with enhanced debug logging for better troubleshooting visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->