### PR TITLE
fix(grounding): add concrete citation example to prevent verbose format (fixes #18)

### DIFF
--- a/ragpipe/grounding.py
+++ b/ragpipe/grounding.py
@@ -26,7 +26,7 @@ audit_log = logging.getLogger("ragpipe.audit")
 
 DEFAULT_SYSTEM_PROMPT = """You are a knowledgeable assistant with access to a curated document corpus. Use the following rules when answering:
 
-1. If the retrieved documents contain relevant information, use them as your primary source. Cite every claim drawn from the documents using [doc_id:chunk_id]. Answer directly from the document content — do not second-guess what the document is. If the text says it is a particular law, act, or report, treat it as that document.
+1. If the retrieved documents contain relevant information, use them as your primary source. Cite every claim drawn from the documents using the exact format [doc_id:chunk_id] — for example, [133abba5-9e3f-4b1a-8c7d-2f6e8a0b3d4c:2]. Do NOT use verbose formats like [doc_id:133abba5...:chunk_id:2]. Answer directly from the document content — do not second-guess what the document is. If the text says it is a particular law, act, or report, treat it as that document.
 
 2. Only use the "⚠️ Not in corpus:" prefix when NONE of the retrieved documents are relevant to the question. If you cite even one document, do NOT start with or include "⚠️ Not in corpus:" — the answer IS from the corpus. Partial coverage is still corpus coverage.
 

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -61,6 +61,13 @@ def test_system_prompt_contains_not_in_corpus_marker():
     assert "⚠️ Not in corpus:" in mod.DEFAULT_SYSTEM_PROMPT
 
 
+def test_system_prompt_contains_concrete_citation_example():
+    """System prompt must include a concrete citation example to prevent verbose format."""
+    mod = _reload()
+    assert "[133abba5-9e3f-4b1a-8c7d-2f6e8a0b3d4c:2]" in mod.DEFAULT_SYSTEM_PROMPT
+    assert "Do NOT use verbose formats" in mod.DEFAULT_SYSTEM_PROMPT
+
+
 # ── Context formatting ───────────────────────────────────────────────────────
 
 
@@ -119,6 +126,23 @@ def test_parse_citations_ignores_malformed():
     cites = mod.parse_citations(text)
     assert len(cites) == 1
     assert cites[0] == ("abc-123", 5)
+
+
+def test_parse_citations_rejects_verbose_format():
+    """Verbose format [doc_id:...:chunk_id:N] must not match — only [hash:N] is valid."""
+    mod = _reload()
+    verbose = "[doc_id:133abba5-9e3f-4b1a-8c7d-2f6e8a0b3d4c:chunk_id:2]"
+    cites = mod.parse_citations(verbose)
+    assert cites == [], f"Verbose citation should be rejected, got {cites}"
+
+
+def test_parse_citations_accepts_correct_format_alongside_verbose():
+    """Correct [hash:N] citations must still parse when verbose ones are also present."""
+    mod = _reload()
+    text = "See [doc_id:133abba5:chunk_id:2] for details. Also [133abba5-9e3f-4b1a-8c7d-2f6e8a0b3d4c:2] confirms this."
+    cites = mod.parse_citations(text)
+    assert len(cites) == 1
+    assert cites[0] == ("133abba5-9e3f-4b1a-8c7d-2f6e8a0b3d4c", 2)
 
 
 # ── Citation validation ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #18

## Problem
Model was emitting `[doc_id:133abba5...:chunk_id:2]` instead of the expected `[133abba5...:2]` format. The citation regex correctly rejects this verbose format, but valid citations were being lost — causing grounding to be misclassified as general.

## Solution
- Added a concrete citation example (`[133abba5-9e3f-4b1a-8c7d-2f6e8a0b3d4c:2]`) to the system prompt
- Added explicit "Do NOT use verbose formats" instruction
- Added regression tests confirming verbose format is rejected by the parser
- Added test confirming correct format still parses alongside verbose ones

## Testing
- 145 tests pass (3 new: `test_parse_citations_rejects_verbose_format`, `test_parse_citations_accepts_correct_format_alongside_verbose`, `test_system_prompt_contains_concrete_citation_example`)
- `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved citation format validation to enforce consistent formatting standards and reject non-compliant citation syntax variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->