### PR TITLE
fix(grounding): deduplicate cited_chunks in streaming responses (fixes #17)

### DIFF
--- a/ragpipe/grounding.py
+++ b/ragpipe/grounding.py
@@ -345,8 +345,14 @@ def build_metadata(
         except Exception:
             log.warning("Failed to resolve titles from docstore for metadata", exc_info=True)
 
+    # Deduplicate citations preserving insertion order — the model may
+    # reference the same chunk multiple times in a response.
+    seen: set[tuple[str, int]] = set()
     cited_chunks = []
     for d, c in valid_citations:
+        if (d, c) in seen:
+            continue
+        seen.add((d, c))
         chunk_data = title_lookup.get((d, c), {})
         cited_chunks.append(
             {

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -286,6 +286,25 @@ def test_metadata_general():
     assert meta["corpus_coverage"] == "none"
 
 
+def test_metadata_deduplicates_cited_chunks():
+    """Duplicate citations from streaming must produce unique cited_chunks."""
+    mod = _reload()
+    # Simulate model citing the same chunk 6 times
+    duplicated = [("a", 2)] * 6 + [("a", 4)] * 3
+    meta = mod.build_metadata("Answer [a:2] [a:2] [a:4] [a:2]", duplicated, "full")
+    ids = [c["id"] for c in meta["cited_chunks"]]
+    assert ids == ["a:2", "a:4"], f"Expected deduplicated list, got {ids}"
+
+
+def test_metadata_dedup_preserves_insertion_order():
+    """Deduplication must preserve the order of first occurrence."""
+    mod = _reload()
+    citations = [("b", 1), ("a", 0), ("b", 1), ("a", 0), ("c", 3)]
+    meta = mod.build_metadata("text", citations, "full")
+    ids = [c["id"] for c in meta["cited_chunks"]]
+    assert ids == ["b:1", "a:0", "c:3"]
+
+
 # ── Audit logging ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #17

## Problem
Streaming path produces duplicate entries in `cited_chunks`. The same chunk appears multiple times (e.g. chunk_id 2 cited 6 times) in both `rag_metadata` and `query_log` because `parse_citations()` returns one entry per occurrence and `build_metadata()` didn't deduplicate.

## Solution
Added deduplication in `build_metadata()` using a seen-set, preserving insertion order. This fixes both streaming and non-streaming paths since both call `build_metadata()`.

## Testing
- 144 tests pass (2 new: `test_metadata_deduplicates_cited_chunks`, `test_metadata_dedup_preserves_insertion_order`)
- `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)