### PR TITLE
fix(docstore): use TIMESTAMPTZ for chunks.created_at (refs rag-suite#6)

### DIFF
--- a/ragpipe/docstore.py
+++ b/ragpipe/docstore.py
@@ -98,7 +98,7 @@ class PostgresDocstore(DocstoreBackend):
                     text       TEXT NOT NULL,
                     source     TEXT NOT NULL DEFAULT '',
                     title      TEXT NOT NULL DEFAULT '',
-                    created_at TEXT NOT NULL DEFAULT '',
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     PRIMARY KEY (doc_id, chunk_id)
                 )
             """)
@@ -123,31 +123,29 @@ class PostgresDocstore(DocstoreBackend):
 
     def upsert_chunk(self, doc_id: str, chunk_id: int, text: str, source: str, title: str = "") -> None:
         self._ensure_schema()
-        now = datetime.now(UTC).isoformat()
         conn = self._get_sync_conn()
         with conn.cursor() as cur:
             cur.execute(
                 """
-                INSERT INTO chunks (doc_id, chunk_id, text, source, title, created_at)
-                VALUES (%s, %s, %s, %s, %s, %s)
+                INSERT INTO chunks (doc_id, chunk_id, text, source, title)
+                VALUES (%s, %s, %s, %s, %s)
                 ON CONFLICT (doc_id, chunk_id)
                 DO UPDATE SET text = EXCLUDED.text, source = EXCLUDED.source, title = EXCLUDED.title
             """,
-                (doc_id, chunk_id, text, source, title, now),
+                (doc_id, chunk_id, text, source, title),
             )
 
     def upsert_chunks(self, chunks: list[dict]) -> None:
         self._ensure_schema()
-        now = datetime.now(UTC).isoformat()
         conn = self._get_sync_conn()
         with conn.cursor() as cur:
             from psycopg2.extras import execute_values
 
-            values = [(c["doc_id"], c["chunk_id"], c["text"], c["source"], c.get("title", ""), now) for c in chunks]
+            values = [(c["doc_id"], c["chunk_id"], c["text"], c["source"], c.get("title", "")) for c in chunks]
             execute_values(
                 cur,
                 """
-                INSERT INTO chunks (doc_id, chunk_id, text, source, title, created_at)
+                INSERT INTO chunks (doc_id, chunk_id, text, source, title)
                 VALUES %s
                 ON CONFLICT (doc_id, chunk_id)
                 DO UPDATE SET text = EXCLUDED.text, source = EXCLUDED.source, title = EXCLUDED.title


### PR DESCRIPTION
Refs rag-suite#6

## Problem
Postgres chunks table uses `TEXT` for `created_at` and ragpipe writes ISO8601 strings from Python. All other tables use `TIMESTAMPTZ`.

## Solution
- Changed `CREATE TABLE` schema to `TIMESTAMPTZ NOT NULL DEFAULT NOW()`
- Removed Python-side `datetime.now(UTC).isoformat()` from `upsert_chunk` and `upsert_chunks`
- Postgres `DEFAULT NOW()` handles timestamping server-side
- SQLite backend unchanged (no TIMESTAMPTZ support)

## Testing
- 147 tests pass
- `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)