### PR TITLE
feat(ragpipe): add legal/patent route to lennon with mpep collection (fixes #20)

### DIFF
--- a/examples/routes-multi-host.yaml
+++ b/examples/routes-multi-host.yaml
@@ -63,3 +63,23 @@ routes:
       - "How does TCP/IP work?"
     model_url: http://host-b.example.local:8080
     rag_enabled: false
+
+  # Legal / patent queries — route to SaulLM-7B on lennon with USPTO/MPEP collection
+  legal:
+    examples:
+      - "What does the MPEP say about patentability?"
+      - "Find the patent examination guidelines for obviousness"
+      - "What are the requirements for a valid patent claim?"
+      - "Explain the patent prior art requirements"
+      - "What is the statute of limitations for patent infringement?"
+      - "How do I file a provisional patent application?"
+      - "What constitutes patentable subject matter?"
+      - "Describe the patent examination process"
+      - "What are the differences between design and utility patents?"
+      - "Find the relevant patent law provisions for this invention"
+    model_url: http://lennon:8080
+    qdrant_url: http://host.containers.internal:6333
+    qdrant_collection: mpep
+    docstore_url: postgresql://user:pass@host.containers.internal:5432/ragpipe
+    reranker_top_n: 5
+    top_k: 20


### PR DESCRIPTION
Closes #20

## Problem
Need a semantic router route that classifies legal and patent queries and routes them to SaulLM-7B on lennon with the mpep Qdrant collection.

## Solution
Added `legal` route to `examples/routes-multi-host.yaml`:
- `model_url: http://lennon:8080` — SaulLM-7B endpoint on lennon
- `qdrant_collection: mpep` — USPTO/MPEP patent collection
- `docstore_url` pointing to the local postgres docstore
- 10 example utterances covering patent law queries

## Usage
To enable this route in production:
1. Copy `examples/routes-multi-host.yaml` to the location pointed by `RAGPIPE_ROUTES_FILE`
2. Update `docstore_url` with the actual postgres credentials
3. Hot-reload: `POST /admin/reload-routes` with admin token

## Testing
- 14 router tests pass
- Verified route loads correctly with `load_routes_config()`