### PR TITLE
fix(grounding): elicit citation markers from small MoE models

### DIFF
--- a/ragpipe/grounding.py
+++ b/ragpipe/grounding.py
@@ -34,7 +34,12 @@ DEFAULT_SYSTEM_PROMPT = """You are a knowledgeable assistant with access to a cu
 
 4. Never present general knowledge as if it came from the retrieved documents. Never fabricate citations.
 
-5. If you are uncertain whether your general knowledge is accurate, say so explicitly rather than stating it with false confidence."""
+5. If you are uncertain whether your general knowledge is accurate, say so explicitly rather than stating it with false confidence.
+
+## Example
+
+User: What does the report say about cloud adoption?
+Assistant: According to the Q3 Strategy Report, cost reduction is the top driver of cloud adoption [e3a1b2c4-5f6d-7890-abcd-ef1234567890:3]. The report also identifies scalability as a key factor, noting that 78% of surveyed teams cited elastic capacity as a requirement [e3a1b2c4-5f6d-7890-abcd-ef1234567890:7]. A separate Compliance Review highlights regulatory mandates as an accelerant for migration [f4b2c3d5-6a7e-8901-bcde-f12345678901:2]."""
 
 DEFAULT_SYSTEM_PROMPT_HASH = hashlib.sha256(DEFAULT_SYSTEM_PROMPT.encode()).hexdigest()
 
@@ -159,7 +164,10 @@ def build_system_message(context: str, *, system_prompt: str | None = None) -> s
     """
     prompt = system_prompt or SYSTEM_PROMPT
     if context:
-        return f"{prompt}\n\n--- DOCUMENT CONTEXT ---\n{context}\n--- END CONTEXT ---"
+        return (
+            f"{prompt}\n\n--- DOCUMENT CONTEXT ---\n{context}\n--- END CONTEXT ---\n\n"
+            "REMINDER: Cite every claim from the documents above using [doc_id:chunk_id] format."
+        )
     else:
         return f"{prompt}\n\nNo relevant documents were retrieved for this query."
 

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -68,6 +68,19 @@ def test_system_prompt_contains_concrete_citation_example():
     assert "Do NOT use verbose formats" in mod.DEFAULT_SYSTEM_PROMPT
 
 
+def test_system_prompt_contains_few_shot_example():
+    """System prompt must include a few-shot Q&A showing citation usage."""
+    mod = _reload()
+    assert "## Example" in mod.DEFAULT_SYSTEM_PROMPT
+    assert "Assistant:" in mod.DEFAULT_SYSTEM_PROMPT
+    # The example response must contain at least one citation in the expected format
+    from ragpipe.grounding import _CITATION_PATTERN
+
+    example_start = mod.DEFAULT_SYSTEM_PROMPT.index("## Example")
+    example_text = mod.DEFAULT_SYSTEM_PROMPT[example_start:]
+    assert _CITATION_PATTERN.search(example_text), "Few-shot example must contain valid [doc_id:chunk_id] citations"
+
+
 # ── Context formatting ───────────────────────────────────────────────────────
 
 
@@ -95,6 +108,24 @@ def test_build_system_message_with_context():
     assert "DOCUMENT CONTEXT" in msg
     assert "some context" in msg
     assert mod.SYSTEM_PROMPT in msg
+
+
+def test_build_system_message_has_citation_reminder_after_context():
+    """Citation format reminder must appear after the context block to reinforce
+    the instruction for models with limited attention over long contexts."""
+    mod = _reload()
+    msg = mod.build_system_message("some context")
+    end_ctx_pos = msg.index("--- END CONTEXT ---")
+    reminder_pos = msg.index("REMINDER:")
+    assert reminder_pos > end_ctx_pos, "Citation reminder must appear after END CONTEXT"
+    assert "[doc_id:chunk_id]" in msg[end_ctx_pos:]
+
+
+def test_build_system_message_no_reminder_without_context():
+    """When there's no context, there should be no citation reminder."""
+    mod = _reload()
+    msg = mod.build_system_message("")
+    assert "REMINDER:" not in msg
 
 
 def test_build_system_message_empty_retrieval():


### PR DESCRIPTION
## Summary
- Add few-shot Q&A example to `DEFAULT_SYSTEM_PROMPT` demonstrating document titles in prose alongside `[doc_id:chunk_id]` citation markers
- Add post-context `REMINDER:` line in `build_system_message()` to reinforce citation format after long context blocks
- 3 new tests: few-shot example validation, post-context reminder positioning, no reminder without context

## Root cause
Qwen3.5-35B-A3B (3B active params) reads injected context and answers from it, but ignores citation format instructions at the top of the system prompt. Attention decays over long context blocks, so the formatting rules lose salience by generation time.

## E2E verification
Tested against live stack with updated `system-prompt.txt`:

| Query | Before | After |
|-------|--------|-------|
| NATO interop | 0 citations, general | 9 citations, corpus, titles in prose |
| Red Hat strategy | 0 citations, general | 1 citation, general (correct — no strategy doc) |
| MPEP 2106 | 0 citations, general | 0 citations, general (correct — section not in corpus) |

Also updated `~/.config/ragpipe/system-prompt.txt` (production override) with matching few-shot example.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated system prompt with concrete examples demonstrating proper citation format
  * Enhanced message generation to include citation reminders when context is provided

* **Tests**
  * Added test coverage for citation format validation in prompts
  * Added test cases verifying citation reminder behavior with and without context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->