### PR TITLE
docs: synchronize documentation with current implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,19 +68,7 @@ docs/
 - Models downloaded from HuggingFace Hub, cached in RAGPIPE_MODEL_CACHE
 - Default embedding model (Alibaba-NLP/gte-modernbert-base) is quantized ONNX, 768d, CLS pooling
 
-## MIGraphX — AMD GPU inference (gfx1151 only)
-
-MIGraphXExecutionProvider is the correct and intended AMD GPU execution
-provider for ONNX Runtime on this system. ROCMExecutionProvider is
-ABI-incompatible with ROCm 7.x (`onnxruntime-rocm` links against
-ROCm 6.x `.so` versions — `libhipblas.so.2` vs `.so.3`,
-`libamdhip64.so.6` vs `.so.7`). It silently falls back to CPU.
-
-MIGraphX compiles static computation graphs at first use (JIT). All inputs
-must be padded to a fixed batch size (`MIGRAPHX_BATCH_SIZE=64`) before
-inference and sliced after. The startup warmup must use exactly 64 inputs
-so the compiled graph matches production traffic — one compile, cached
-forever.
+## MIGraphX — AMD GPU inference (non-gfx1151 only)
 
 **On gfx1151 (Strix Halo), both embedder and reranker use CPU.** MIGraphX
 is skipped automatically via `_is_gfx1151()` detection (checks /proc/cpuinfo
@@ -91,23 +79,33 @@ for "Strix Halo" or Family 26 + Model 112). This is because:
 
 **On other AMD GPUs (non-UMA), MIGraphX is used normally.**
 
+**MXR pre-compilation cache — 39x startup improvement:**
+
+The MXR cache uses `ORT_MIGRAPHX_MODEL_CACHE_PATH` to store pre-compiled
+ONNX models in `.mxr` format. On first startup, models are compiled and
+cached (~149 MB per model). Subsequent startups load from cache directly:
+
+| Startup | Time | Mechanism |
+|---|---|---|
+| Cold (first ever) | ~3:53 | JIT compilation |
+| Warm (MXR cached) | ~6 seconds | Load from `ORT_MIGRAPHX_MODEL_CACHE_PATH` |
+
 **`RAGPIPE_FORCE_CPU=1`** can force CPU-only mode on any platform.
 
 **`RAGPIPE_DEVICE=cpu|migraphx|cuda`** to select a specific provider.
 
-**⚠️ Startup time with MIGraphX: ~3 minutes.** Do not restart ragpipe in
-production unless critical.
+**⚠️ Cold start: ~3:53 on first boot.** Warm start (MXR cached): ~6 seconds.
+Do not restart ragpipe in production unless critical.
 
-`RAG_TOP_K` must never exceed `MIGRAPHX_BATCH_SIZE`. An assertion at startup
-enforces this. Do not remove it.
+`RAG_TOP_K` must never exceed `MIGRAPHX_BATCH_SIZE` when MIGraphX is used (non-gfx1151).
+An assertion at startup enforces this. Do not remove it.
 
-The reranker always runs on CPU — MIGraphX compiles the MiniLM-L-6 reranker
-graph on gfx1151 but fails at inference with "Not computable:
-gpu::precompile_op". The embedder also runs on CPU on gfx1151 (auto-detected).
+The reranker always runs on CPU — MIGraphX fails at inference with
+"Not computable: gpu::precompile_op" for this model. On gfx1151, the
+embedder also runs on CPU (auto-detected).
 
 Do not attempt to switch to ROCMExecutionProvider — it will fail with ABI
-errors against ROCm 7.x and is no longer maintained by AMD. The only
-alternative is CPUExecutionProvider, which works but is significantly slower.
+errors against ROCm 7.x. CPUExecutionProvider is the fallback.
 
 ## Multi-collection routing
 
@@ -142,6 +140,8 @@ cited_chunks = [
 | Change | Impact |
 |--------|--------|
 | Drop fastembed → raw ONNX Runtime | 83% memory reduction (4.1 GB → 708 MB), 5x faster startup, ~17% faster avg query |
+| MXR pre-compilation cache | 39x startup improvement (3:53 cold → 6s warm) via `ORT_MIGRAPHX_MODEL_CACHE_PATH` |
+| CPU on gfx1151 (PR #42) | Embedder + reranker run on CPU — MIGraphX GTT on UMA APUs is slower than CPU for small models |
 | asyncpg connection pool | Native async hydration, frees thread pool worker per request |
 | LRU chunk cache (2,048 entries) | 55% faster repeated queries (eliminates Postgres round-trip on cache hit) |
 | Persistent httpx client | Saves 1-5ms/request TCP handshake overhead |
@@ -153,7 +153,7 @@ cited_chunks = [
 ## Running tests
 ```bash
 pip install '.[dev]'
-python -m pytest tests/ -v    # 97 tests
+python -m pytest tests/ -v    # 164 tests
 ruff check && ruff format --check
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,19 +129,31 @@ All configuration is via environment variables.
 
 For the full reference covering routing configuration and debugging, see [docs/routing.md](docs/routing.md).
 
-## GPU acceleration (MIGraphX)
+## GPU acceleration (gfx1151: CPU; other AMD: MIGraphX)
 
-ragpipe supports AMD GPU inference via MIGraphXExecutionProvider. This is the **only** supported AMD GPU provider on this stack — ROCMExecutionProvider is ABI-incompatible with ROCm 7.x and silently falls back to CPU.
+**On gfx1151 (Strix Halo), both embedder and reranker use CPU.** MIGraphX is skipped automatically via `_is_gfx1151()` detection. This is because MIGraphX tensors land in GTT (system RAM) on UMA APUs, not VRAM — ROCm VMM is not supported on gfx1151 by design. Benchmarks confirm CPU outperforms MIGraphX-on-GTT for models this small.
 
-**⚠️ Startup time:** MIGraphX compiles static computation graphs at first use (JIT). The first query after startup takes ~3 minutes on gfx1151 while the graph is compiled. Subsequent queries are fast. Do not restart ragpipe in production unless necessary.
+**On other AMD GPUs**, MIGraphXExecutionProvider is used normally. ROCMExecutionProvider is ABI-incompatible with ROCm 7.x and silently falls back to CPU.
+
+**MXR pre-compilation cache — 39x startup improvement:**
+
+On first startup, ragpipe compiles ONNX models to `.mxr` format via `ORT_MIGRAPHX_MODEL_CACHE_PATH`. Subsequent startups load pre-compiled `.mxr` files directly (non-gfx1151 AMD GPUs with MIGraphX):
+
+| Startup type | Time | Mechanism |
+|---|---|---|
+| Cold (first ever) | ~3:53 | JIT compilation |
+| Warm (.mxr cached) | ~6 seconds | Load from `ORT_MIGRAPHX_MODEL_CACHE_PATH` |
+
+Cached files are ~149 MB per model. The cache persists across restarts — do not restart ragpipe casually; the warm path is fast enough for development but the cold path still takes ~4 minutes.
 
 ```
-Environment requirements for MIGraphX:
-- HSA_OVERRIDE_GFX_VERSION=11.5.1 (required for gfx1151)
-- MIGRAPHX_BATCH_SIZE=64 (must be ≥ RAG_TOP_K; assertion enforces this at startup)
+Environment for MXR cache (non-gfx1151 MIGraphX):
+- ORT_MIGRAPHX_MODEL_CACHE_PATH=/home/default/.cache/ragpipe/mxr
 ```
 
-The reranker (MiniLM-L-6-v2) runs on CPU — MIGraphX fails at inference with "Not computable: gpu::precompile_op" for this model.
+On gfx1151, the embedder and reranker use CPU instead of MIGraphX, so MXR caching does not apply. The cold start still takes ~3:53 on first boot for ONNX model JIT compilation.
+
+**⚠️ Cold start: ~3:53 on first query.** Warm start (MXR cached, non-gfx1151): ~6 seconds. Plan restarts accordingly.
 
 ## Prometheus metrics
 
@@ -160,13 +172,13 @@ ragpipe_chunks_retrieved_total 5678
 # TYPE ragpipe_invalid_citations_total counter
 ragpipe_invalid_citations_total 12
 
-# HELP ragpipe_embed_cache_hits_total Embedding cache hits
-# TYPE ragpipe_embed_cache_hits_total counter
-ragpipe_embed_cache_hits_total 890
+# HELP ragpipe_embed_cache_hits Embedding cache hits
+# TYPE ragpipe_embed_cache_hits counter
+ragpipe_embed_cache_hits 890
 
-# HELP ragpipe_embed_cache_misses_total Embedding cache misses
-# TYPE ragpipe_embed_cache_misses_total counter
-ragpipe_embed_cache_misses_total 344
+# HELP ragpipe_embed_cache_misses Embedding cache misses
+# TYPE ragpipe_embed_cache_misses counter
+ragpipe_embed_cache_misses 344
 
 # HELP ragpipe_request_duration_seconds Request latency histogram
 # TYPE ragpipe_request_duration_seconds histogram
@@ -180,11 +192,12 @@ ragpipe_request_duration_seconds_bucket{le="0.5"} 500
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/health` | Health check |
+| `GET` | `/metrics` | Prometheus metrics |
 | `GET` | `/admin/config` | Returns current routing and system prompt configuration |
+| `GET` | `/admin/mxr-status` | Returns MXR cache status (cached models, file sizes) |
 | `POST` | `/admin/reload-prompt` | Hot-reload system prompt from file/env (requires `RAGPIPE_ADMIN_TOKEN`) |
 | `POST` | `/admin/reload-routes` | Hot-reload routes from `RAGPIPE_ROUTES_FILE` (requires `RAGPIPE_ADMIN_TOKEN`) |
-| `POST` | `/admin/reload-system-prompt` | Alias for `/admin/reload-prompt` (requires `RAGPIPE_ADMIN_TOKEN`) |
-| `POST` | `/admin/classify` | Test route classification without a real query (requires `RAGPIPE_ADMIN_TOKEN`) |
+| `POST` | `/admin/compile-mxr` | Trigger MXR pre-compilation (non-blocking, returns 202; requires `RAGPIPE_ADMIN_TOKEN`) |
 
 ```bash
 # Reload system prompt (hot-reload, no restart needed)
@@ -199,11 +212,13 @@ curl -X POST http://localhost:8090/admin/reload-routes \
 curl http://localhost:8090/admin/config \
   -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN"
 
-# Test route classification
-curl -X POST http://localhost:8090/admin/classify \
-  -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "What does the NDAA say about AI?"}'
+# Get MXR cache status
+curl http://localhost:8090/admin/mxr-status \
+  -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN"
+
+# Trigger MXR pre-compilation (non-blocking)
+curl -X POST http://localhost:8090/admin/compile-mxr \
+  -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN"
 ```
 
 ## rag_metadata
@@ -238,7 +253,7 @@ titles = [c["title"] for c in response.rag_metadata["cited_chunks"]]
 
 ## Known issues
 
-- **⚠️ MIGraphX startup (~3 min):** The first query after ragpipe startup takes ~3 minutes while MIGraphX compiles the inference graph. Plan restarts accordingly. Do not restart ragpipe in production unless critical.
+- **⚠️ Cold start (~3:53):** First query after ragpipe startup takes ~3:53 while ONNX models are compiled. Warm start (MXR cached): ~6 seconds. Do not restart ragpipe in production unless critical.
 - **Streaming citation stripping**: Streaming responses are audited and validated post-hoc (dual-path accumulation), but invalid citations cannot be stripped because the text has already been delivered to the client. Invalid citations are logged as errors. Non-streaming requests strip invalid citations before delivery.
 - **LLM phrasing variance**: The negative finding classifier depends on the model using recognizable negation patterns ("no evidence", "not mentioned", etc.) before the `⚠️` marker. When the model phrases its negative finding differently, the response may be classified as `mixed` instead of `general`.
 - **Passthrough model list**: `/v1/models` passthrough always returns the global upstream's model list, not the routed model's list.
@@ -248,7 +263,7 @@ titles = [c["title"] for c in response.rag_metadata["cited_chunks"]]
 
 ```bash
 pip install '.[dev]'
-python -m pytest tests/ -v
+python -m pytest tests/ -v    # 164 tests
 ruff check && ruff format --check
 ```
 


### PR DESCRIPTION
Comprehensive documentation update based on all issues and PRs merged since the last audit.

Key changes:
- MXR cache documented (39x startup improvement): cold start ~3:53, warm start ~6s via ORT_MIGRAPHX_MODEL_CACHE_PATH
- /admin/mxr-status and /admin/compile-mxr endpoints added to admin API
- GPU on gfx1151: CPU for embedder/reranker (MIGraphX tensors land in GTT on UMA APUs)
- Prometheus metrics updated counter naming
- CLAUDE.md updated with CPU on gfx1151 and MXR cache details
- Test count: 164 tests (up from 97)

Closes #39 (admin token)
Closes #38 (citation errors)
Closes #37 (duplicate cited_chunks)
Closes #36 (CPU on gfx1151)
Closes #34 (citation markers)
Closes #24 (Prometheus endpoint)
Closes #16 (MXR pre-compilation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified AMD GPU support with automatic CPU fallback for gfx1151 devices
  * Documented MXR pre-compilation caching feature via new environment variable for improved performance
  * Updated startup timing information (cold: ~3:53, warm: ~6s)
  * Revised Admin API endpoints and metrics naming conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->