### PR TITLE
feat: implement Corrective RAG (CRAG) query rewrite (fixes #45)

### DIFF
--- a/ragpipe/app.py
+++ b/ragpipe/app.py
@@ -187,6 +187,9 @@ async def _write_query_log(
     model: str | None,
     route: str | None,
     collection_id: str | None,
+    retrieval_attempts: int = 1,
+    query_rewritten: bool = False,
+    original_query: str | None = None,
 ) -> None:
     """Write a completed request to query_log. Fire-and-forget, never surfaces errors."""
     try:
@@ -198,8 +201,9 @@ async def _write_query_log(
                 """
                 INSERT INTO query_log
                     (collection_id, query_text, query_hash, grounding, cited_chunks,
-                     total_chunks, latency_ms, model, route)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                     total_chunks, latency_ms, model, route,
+                     retrieval_attempts, query_rewritten, original_query)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
                 """,
                 collection_id,
                 query_text,
@@ -210,6 +214,9 @@ async def _write_query_log(
                 latency_ms,
                 model,
                 route,
+                retrieval_attempts,
+                query_rewritten,
+                original_query,
             )
     except Exception:
         log.warning("Failed to write query_log entry — continuing", exc_info=True)
@@ -508,19 +515,56 @@ def _rerank_sync(
     return rerank(query, candidates, min_score=min_score, top_n=top_n)
 
 
+async def _rewrite_query(query: str, *, pipeline=None) -> str:
+    """Use the LLM to rewrite a query that returned no results.
+
+    Calls the route's model (or global MODEL_URL) with /nothink to
+    disable thinking mode and get a concise rewritten query.
+    """
+    target_url = pipeline.config.model_url if pipeline else MODEL_URL
+    prompt = (
+        f"Given the question: '{query}'\n"
+        "The retrieval system found no relevant documents.\n"
+        "Rewrite this question to be more likely to find relevant information.\n"
+        "Return only the rewritten question, nothing else."
+    )
+    payload = {
+        "model": "default",
+        "messages": [{"role": "user", "content": f"/nothink\n{prompt}"}],
+        "temperature": 0,
+        "max_tokens": 200,
+    }
+    try:
+        resp = await _http_client.post(
+            f"{target_url}/v1/chat/completions",
+            json=payload,
+            timeout=60,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        rewritten = data["choices"][0]["message"].get("content", "").strip()
+        if rewritten:
+            log.info("CRAG rewrite: '%s' → '%s'", query[:80], rewritten[:80])
+            return rewritten
+    except Exception:
+        log.warning("CRAG query rewrite failed — using original query", exc_info=True)
+    return query
+
+
 async def retrieve_and_rerank(
     user_query: str,
     *,
     pipeline=None,
-) -> tuple[list[dict], list[dict]]:
-    """Full async retrieval pipeline: Qdrant → hydrate → rerank.
+) -> tuple[list[dict], list[dict], dict]:
+    """Full async retrieval pipeline: Qdrant → hydrate → rerank → CRAG retry.
 
     When pipeline is provided, uses per-route resources. Otherwise
     falls back to module-level singletons (backward compatible).
 
-    Returns (ranked_chunks, all_retrieved_refs) where all_retrieved_refs
-    is the full set of hydrated results before reranking, needed for
-    citation validation.
+    Implements Corrective RAG (CRAG): if reranking filters out all chunks
+    (low confidence), rewrites the query via LLM and retries once.
+
+    Returns (ranked_chunks, all_retrieved_refs, crag_metadata).
     """
     loop = asyncio.get_running_loop()
 
@@ -541,10 +585,36 @@ async def retrieve_and_rerank(
         rerank_kwargs = {}
         ds = None
 
+    crag_meta = {
+        "retrieval_attempts": 1,
+        "query_rewritten": False,
+    }
+
     refs = await loop.run_in_executor(_embed_executor, lambda: _search_qdrant_sync(user_query, **search_kwargs))
     candidates = await _hydrate(refs, ds=ds)
     ranked = await loop.run_in_executor(_rerank_executor, lambda: _rerank_sync(user_query, candidates, **rerank_kwargs))
-    return ranked, candidates
+
+    # CRAG: if reranking filtered everything, rewrite and retry once
+    if not ranked and candidates:
+        rewritten = await _rewrite_query(user_query, pipeline=pipeline)
+        if rewritten != user_query:
+            crag_meta["retrieval_attempts"] = 2
+            crag_meta["query_rewritten"] = True
+            crag_meta["original_query"] = user_query
+            crag_meta["rewritten_query"] = rewritten
+
+            log.info("CRAG retry: %d candidates scored below threshold, retrying with rewritten query", len(candidates))
+            refs2 = await loop.run_in_executor(_embed_executor, lambda: _search_qdrant_sync(rewritten, **search_kwargs))
+            candidates2 = await _hydrate(refs2, ds=ds)
+            ranked2 = await loop.run_in_executor(
+                _rerank_executor, lambda: _rerank_sync(rewritten, candidates2, **rerank_kwargs)
+            )
+
+            # Merge candidates for citation validation (both attempts)
+            all_candidates = candidates + [c for c in candidates2 if c not in candidates]
+            return ranked2, all_candidates, crag_meta
+
+    return ranked, candidates, crag_meta
 
 
 # ── Request processing ───────────────────────────────────────────────────────
@@ -577,9 +647,9 @@ async def process_chat_request(body: dict, *, pipeline=None) -> tuple[dict, dict
     rag_enabled = pipeline.config.rag_enabled if pipeline else True
 
     if rag_enabled:
-        ranked, all_candidates = await retrieve_and_rerank(user_query, pipeline=pipeline)
+        ranked, all_candidates, crag_meta = await retrieve_and_rerank(user_query, pipeline=pipeline)
     else:
-        ranked, all_candidates = [], []
+        ranked, all_candidates, crag_meta = [], [], {"retrieval_attempts": 1, "query_rewritten": False}
 
     corpus_coverage = determine_corpus_coverage(ranked)
 
@@ -630,6 +700,7 @@ async def process_chat_request(body: dict, *, pipeline=None) -> tuple[dict, dict
         "corpus_coverage": corpus_coverage,
         "user_query": user_query,
         "docstore": effective_ds,
+        "crag": crag_meta,
     }
 
 
@@ -700,6 +771,17 @@ def process_response(response_data: dict, ctx: dict) -> tuple[dict, dict]:
         except Exception:
             log.exception("Failed to resolve chunk titles for cited chunks")
 
+    # Add CRAG metadata if query was rewritten
+    crag = ctx.get("crag", {})
+    if crag.get("query_rewritten"):
+        metadata["retrieval_attempts"] = crag["retrieval_attempts"]
+        metadata["query_rewritten"] = True
+        metadata["original_query"] = crag.get("original_query")
+        metadata["rewritten_query"] = crag.get("rewritten_query")
+    else:
+        metadata["retrieval_attempts"] = crag.get("retrieval_attempts", 1)
+        metadata["query_rewritten"] = False
+
     # Attach metadata to the response
     response_data["rag_metadata"] = metadata
 
@@ -767,6 +849,17 @@ def _validate_streamed_response(content: str, ctx: dict) -> dict:
             cited_chunk_titles = effective_ds.get_chunks(valid_citations)
         except Exception:
             log.exception("Failed to resolve chunk titles for cited chunks (streaming)")
+
+    # Add CRAG metadata for streaming responses
+    crag = ctx.get("crag", {})
+    if crag.get("query_rewritten"):
+        metadata["retrieval_attempts"] = crag["retrieval_attempts"]
+        metadata["query_rewritten"] = True
+        metadata["original_query"] = crag.get("original_query")
+        metadata["rewritten_query"] = crag.get("rewritten_query")
+    else:
+        metadata["retrieval_attempts"] = crag.get("retrieval_attempts", 1)
+        metadata["query_rewritten"] = False
 
     log_audit(
         q_hash=query_hash(user_query),
@@ -937,6 +1030,9 @@ async def chat_completions(request: Request):
                             model=model,
                             route=route_name,
                             collection_id=None,
+                            retrieval_attempts=metadata.get("retrieval_attempts", 1),
+                            query_rewritten=metadata.get("query_rewritten", False),
+                            original_query=metadata.get("original_query"),
                         ),
                         name="query_log_write",
                     )
@@ -977,6 +1073,9 @@ async def chat_completions(request: Request):
                     model=model,
                     route=route_name,
                     collection_id=None,
+                    retrieval_attempts=metadata.get("retrieval_attempts", 1),
+                    query_rewritten=metadata.get("query_rewritten", False),
+                    original_query=metadata.get("original_query"),
                 ),
                 name="query_log_write",
             )

--- a/tests/test_crag.py
+++ b/tests/test_crag.py
@@ -1,0 +1,228 @@
+"""Tests for Corrective RAG (CRAG) — query rewrite on low retrieval confidence.
+
+Verifies the CRAG pattern in retrieve_and_rerank():
+- Rewrite triggered when reranking filters all chunks (low confidence)
+- No rewrite when reranking passes chunks (high confidence)
+- Maximum 1 retry
+- CRAG metadata fields populated correctly
+- Fallback to general when retry also fails
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import ragpipe.app as app
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _patch_globals(monkeypatch):
+    """Patch module-level singletons needed by retrieve_and_rerank."""
+    monkeypatch.setattr(app, "_http_client", MagicMock())
+    monkeypatch.setattr(app, "MODEL_URL", "http://test:8080")
+
+
+def _make_chunk(doc_id="abc-123", chunk_id=0, text="test text", score=5.0):
+    return {
+        "doc_id": doc_id,
+        "chunk_id": chunk_id,
+        "text": text,
+        "title": "Test",
+        "source": "test://source",
+        "reranker_score": score,
+    }
+
+
+# ── test_crag_no_rewrite_on_high_confidence ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crag_no_rewrite_on_high_confidence():
+    """When reranking returns chunks, CRAG should NOT trigger a rewrite."""
+    chunks = [_make_chunk(score=5.0)]
+
+    with (
+        patch.object(app, "_search_qdrant_sync", return_value=[{"doc_id": "abc-123", "chunk_id": 0}]),
+        patch.object(app, "_hydrate", new_callable=AsyncMock, return_value=chunks),
+        patch.object(app, "_rerank_sync", return_value=chunks),
+        patch.object(app, "_rewrite_query", new_callable=AsyncMock) as mock_rewrite,
+    ):
+        ranked, _candidates, crag_meta = await app.retrieve_and_rerank("test query")
+
+    assert len(ranked) == 1
+    assert crag_meta["retrieval_attempts"] == 1
+    assert crag_meta["query_rewritten"] is False
+    assert "original_query" not in crag_meta
+    mock_rewrite.assert_not_awaited()
+
+
+# ── test_crag_rewrite_on_low_confidence ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crag_rewrite_on_low_confidence():
+    """When reranking filters ALL chunks, CRAG should rewrite and retry."""
+    candidates = [_make_chunk(score=-10.0)]
+    rewritten_chunks = [_make_chunk(doc_id="def-456", score=5.0)]
+
+    call_count = 0
+
+    def search_side_effect(query, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return [{"doc_id": "abc-123" if call_count == 1 else "def-456", "chunk_id": 0}]
+
+    def rerank_side_effect(query, results, **kwargs):
+        # First call: filter everything (low confidence)
+        # Second call: pass chunks (rewritten query found better results)
+        if query == "test query":
+            return []
+        return results
+
+    async def hydrate_side_effect(refs, **kwargs):
+        if refs[0].get("doc_id") == "abc-123":
+            return candidates
+        return rewritten_chunks
+
+    with (
+        patch.object(app, "_search_qdrant_sync", side_effect=search_side_effect),
+        patch.object(app, "_hydrate", new_callable=AsyncMock, side_effect=hydrate_side_effect),
+        patch.object(app, "_rerank_sync", side_effect=rerank_side_effect),
+        patch.object(app, "_rewrite_query", new_callable=AsyncMock, return_value="rewritten test query"),
+    ):
+        ranked, _all_candidates, crag_meta = await app.retrieve_and_rerank("test query")
+
+    assert len(ranked) == 1
+    assert ranked[0]["doc_id"] == "def-456"
+    assert crag_meta["retrieval_attempts"] == 2
+    assert crag_meta["query_rewritten"] is True
+    assert crag_meta["original_query"] == "test query"
+    assert crag_meta["rewritten_query"] == "rewritten test query"
+
+
+# ── test_crag_max_one_retry ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crag_max_one_retry():
+    """CRAG should retry at most once — no infinite loops."""
+    candidates = [_make_chunk(score=-10.0)]
+    search_call_count = 0
+
+    def search_side_effect(query, **kwargs):
+        nonlocal search_call_count
+        search_call_count += 1
+        return [{"doc_id": f"doc-{search_call_count}", "chunk_id": 0}]
+
+    with (
+        patch.object(app, "_search_qdrant_sync", side_effect=search_side_effect),
+        patch.object(app, "_hydrate", new_callable=AsyncMock, return_value=candidates),
+        patch.object(app, "_rerank_sync", return_value=[]),  # Always filter
+        patch.object(app, "_rewrite_query", new_callable=AsyncMock, return_value="rewritten query"),
+    ):
+        ranked, _all_candidates, crag_meta = await app.retrieve_and_rerank("test query")
+
+    # Should have searched exactly 2 times (original + 1 retry), not more
+    assert search_call_count == 2
+    assert crag_meta["retrieval_attempts"] == 2
+    assert len(ranked) == 0  # Both attempts failed
+
+
+# ── test_crag_metadata_fields ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crag_metadata_fields():
+    """CRAG metadata should include all required fields after rewrite."""
+    candidates = [_make_chunk(score=-10.0)]
+
+    with (
+        patch.object(app, "_search_qdrant_sync", return_value=[{"doc_id": "abc-123", "chunk_id": 0}]),
+        patch.object(app, "_hydrate", new_callable=AsyncMock, return_value=candidates),
+        patch.object(app, "_rerank_sync", return_value=[]),
+        patch.object(app, "_rewrite_query", new_callable=AsyncMock, return_value="improved query"),
+    ):
+        _, _, crag_meta = await app.retrieve_and_rerank("original question")
+
+    # All required fields present
+    assert "retrieval_attempts" in crag_meta
+    assert "query_rewritten" in crag_meta
+    assert "original_query" in crag_meta
+    assert "rewritten_query" in crag_meta
+
+    assert crag_meta["retrieval_attempts"] == 2
+    assert crag_meta["query_rewritten"] is True
+    assert crag_meta["original_query"] == "original question"
+    assert crag_meta["rewritten_query"] == "improved query"
+
+
+# ── test_crag_fallback_after_retry ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crag_fallback_after_retry():
+    """When CRAG retry also returns nothing, should fall back to empty results."""
+    candidates = [_make_chunk(score=-10.0)]
+
+    with (
+        patch.object(app, "_search_qdrant_sync", return_value=[{"doc_id": "abc-123", "chunk_id": 0}]),
+        patch.object(app, "_hydrate", new_callable=AsyncMock, return_value=candidates),
+        patch.object(app, "_rerank_sync", return_value=[]),  # Always empty
+        patch.object(app, "_rewrite_query", new_callable=AsyncMock, return_value="better question"),
+    ):
+        ranked, all_candidates, crag_meta = await app.retrieve_and_rerank("bad query")
+
+    # Ranked is empty — CRAG retry also failed
+    assert len(ranked) == 0
+    # But candidates from both attempts should be in all_candidates
+    assert len(all_candidates) >= 1
+    # Metadata shows the retry happened
+    assert crag_meta["retrieval_attempts"] == 2
+    assert crag_meta["query_rewritten"] is True
+
+
+# ── test_crag_no_rewrite_when_no_candidates ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crag_no_rewrite_when_no_candidates():
+    """When Qdrant returns nothing at all, CRAG should not attempt rewrite."""
+    with (
+        patch.object(app, "_search_qdrant_sync", return_value=[]),
+        patch.object(app, "_hydrate", new_callable=AsyncMock, return_value=[]),
+        patch.object(app, "_rerank_sync", return_value=[]),
+        patch.object(app, "_rewrite_query", new_callable=AsyncMock) as mock_rewrite,
+    ):
+        ranked, _candidates, crag_meta = await app.retrieve_and_rerank("query with no results")
+
+    assert len(ranked) == 0
+    assert crag_meta["retrieval_attempts"] == 1
+    assert crag_meta["query_rewritten"] is False
+    # Rewrite should NOT be called — no candidates means no point rewriting
+    mock_rewrite.assert_not_awaited()
+
+
+# ── test_crag_rewrite_query_function ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crag_rewrite_query_function():
+    """_rewrite_query should call the LLM and return the rewritten text."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"choices": [{"message": {"content": "What patent law covers AI systems?"}}]}
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    with patch.object(app, "_http_client", mock_client):
+        result = await app._rewrite_query("AI patent requirements")
+
+    assert result == "What patent law covers AI systems?"
+    # Verify /nothink was included in the prompt
+    call_args = mock_client.post.call_args
+    messages = call_args.kwargs.get("json", call_args.args[1] if len(call_args.args) > 1 else {}).get("messages", [])
+    assert any("/nothink" in msg.get("content", "") for msg in messages)


### PR DESCRIPTION
Closes #45

## Problem
When reranker scores fall below min_score threshold, ragpipe falls back to general knowledge immediately. For ambiguous or poorly-phrased queries, a rewritten query could find relevant documents.

## Solution
Implements the CRAG pattern directly in ragpipe's pipeline (no LangGraph dependency):

```
retrieve → rerank → evaluate confidence
  if HIGH  → generate (unchanged)
  if LOW   → rewrite query via LLM → retrieve again → rerank → generate
  if STILL LOW → fall back to general (unchanged)
```

Key implementation details:
- `_rewrite_query()` calls the LLM with `/nothink` to generate a concise rewritten query
- CRAG only triggers when reranking returns empty but Qdrant had candidates (avoids pointless retries when no vectors match)
- Maximum 1 retry — no infinite loops
- Both retrieval attempts' candidates are merged for citation validation
- `rag_metadata` includes: `retrieval_attempts`, `query_rewritten`, `original_query`, `rewritten_query`
- `query_log` records CRAG columns (requires rag-suite #12 migration — applied)

## Testing
- 7 new CRAG tests added
- 171 total tests passing (164 existing + 7 new)
- Ruff lint clean
- CodeRabbit: no findings

## Reference implementations used
- LangGraph CRAG pattern adapted: https://github.com/langchain-ai/langgraph/blob/main/examples/rag/langgraph_crag.ipynb

## Milestone logging
- Closed ragpipe #46 as duplicate of #45
- Applied rag-suite #12 migration (query_log CRAG columns) to live Postgres
- Phase 0 baseline exists (ragprobe PR #11) — ragprobe comparison pending after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Corrective RAG (CRAG) system enabling automatic query rewriting and retry attempts during retrieval operations.
  * Extended metadata logging to track retrieval attempts, query modification status, and original/rewritten query details.

* **Tests**
  * Added comprehensive test suite validating CRAG control flow, retry mechanisms, and query rewriting across various edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->