### PR TITLE
fix(coderabbit): log query hash instead of raw text, add CRAG columns to schema bootstrap

### DIFF
--- a/ragpipe/app.py
+++ b/ragpipe/app.py
@@ -544,7 +544,7 @@ async def _rewrite_query(query: str, *, pipeline=None) -> str:
         data = resp.json()
         rewritten = data["choices"][0]["message"].get("content", "").strip()
         if rewritten:
-            log.info("CRAG rewrite: '%s' → '%s'", query[:80], rewritten[:80])
+            log.info("CRAG rewrite: %s → %s", query_hash(query), rewritten[:80])
             return rewritten
     except Exception:
         log.warning("CRAG query rewrite failed — using original query", exc_info=True)

--- a/ragpipe/docstore.py
+++ b/ragpipe/docstore.py
@@ -113,6 +113,10 @@ class PostgresDocstore(DocstoreBackend):
                     latency_ms INT,
                     model TEXT,
                     route TEXT,
+                    query_rewritten BOOLEAN DEFAULT FALSE,
+                    original_query TEXT,
+                    rewritten_query TEXT,
+                    retrieval_attempts INT DEFAULT 1,
                     created_at TIMESTAMP DEFAULT now()
                 )
             """)


### PR DESCRIPTION
Fixes two CodeRabbit findings on PR #47:

## Changes

### 1. app.py - Log query hash instead of raw text (Major)
Changed log.info("CRAG rewrite: '%s' to '%s'", query[:80], rewritten[:80]) to use query_hash() instead of raw query text, following the security guideline.

### 2. docstore.py - Add CRAG columns to schema bootstrap (Major)
Fresh deployments using init_schema() would create the query_log table without CRAG columns (query_rewritten, original_query, rewritten_query, retrieval_attempts), causing insert failures. Added these columns to the bootstrap schema.

## Testing
- 171 tests passing (no regression)
- ruff check + format clean
