### PR TITLE
feat(api): expose CRAG metadata in streaming rag_metadata (fixes #50)

### DIFF
--- a/ragpipe/app.py
+++ b/ragpipe/app.py
@@ -990,7 +990,8 @@ async def chat_completions(request: Request):
                                 "object": "chat.completion.chunk",
                             }
                             yield f"data: {json.dumps(summary_chunk)}\n\n"
-                        yield "data: [DONE]\n\n"
+                        # [DONE] is deferred to validate_after_stream so
+                        # rag_metadata can be emitted before it
                         continue
                     try:
                         chunk_data = json.loads(payload)
@@ -1009,7 +1010,13 @@ async def chat_completions(request: Request):
                     yield raw + "\n\n"
 
         async def validate_after_stream(response: StreamingResponse) -> StreamingResponse:
-            """Wrap the streaming response to trigger post-hoc validation."""
+            """Wrap the streaming response to trigger post-hoc validation.
+
+            Emits rag_metadata as a final SSE event before [DONE] so streaming
+            clients can access grounding, citations, retrieval_attempts, and
+            query_rewritten — the same fields non-streaming clients get in the
+            JSON response body.
+            """
             async for chunk in response.body_iterator:
                 yield chunk
             # Stream complete — run citation validation on accumulated text
@@ -1017,6 +1024,9 @@ async def chat_completions(request: Request):
             if full_content:
                 metadata = _validate_streamed_response(full_content, retrieval_ctx)
                 if metadata:
+                    # Emit rag_metadata as SSE event before [DONE]
+                    yield f"data: {json.dumps({'rag_metadata': metadata})}\n\n"
+
                     model = body.get("model")
                     route_name = retrieval_ctx.get("route_name")
                     task = asyncio.create_task(
@@ -1041,6 +1051,7 @@ async def chat_completions(request: Request):
                     # Record Prometheus metrics after streaming completes
                     elapsed = time.monotonic() - request_start
                     _record_query_metrics(elapsed, metadata, retrieval_ctx)
+            yield "data: [DONE]\n\n"
 
         return StreamingResponse(
             validate_after_stream(StreamingResponse(stream_response(), media_type="text/event-stream")),

--- a/tests/test_crag.py
+++ b/tests/test_crag.py
@@ -6,6 +6,7 @@ Verifies the CRAG pattern in retrieve_and_rerank():
 - Maximum 1 retry
 - CRAG metadata fields populated correctly
 - Fallback to general when retry also fails
+- rag_metadata in API response includes CRAG fields (fixes #50)
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -226,3 +227,86 @@ async def test_crag_rewrite_query_function():
     call_args = mock_client.post.call_args
     messages = call_args.kwargs.get("json", call_args.args[1] if len(call_args.args) > 1 else {}).get("messages", [])
     assert any("/nothink" in msg.get("content", "") for msg in messages)
+
+
+# ── test_rag_metadata_includes_crag_fields ──────────────────────────────────
+
+
+def test_process_response_includes_crag_fields_when_rewritten():
+    """process_response should include retrieval_attempts and query_rewritten
+    in rag_metadata when CRAG rewrote the query (fixes #50)."""
+    response_data = {
+        "choices": [{"message": {"content": "Answer with no citations"}}],
+    }
+    ctx = {
+        "user_query": "test query",
+        "ranked": [],
+        "retrieved_set": set(),
+        "corpus_coverage": "none",
+        "crag": {
+            "retrieval_attempts": 2,
+            "query_rewritten": True,
+            "original_query": "test query",
+            "rewritten_query": "improved query",
+        },
+    }
+
+    result_data, _metadata = app.process_response(response_data, ctx)
+
+    assert "rag_metadata" in result_data
+    rag_meta = result_data["rag_metadata"]
+    assert rag_meta["retrieval_attempts"] == 2
+    assert rag_meta["query_rewritten"] is True
+    assert rag_meta["original_query"] == "test query"
+    assert rag_meta["rewritten_query"] == "improved query"
+
+
+def test_process_response_includes_crag_fields_when_not_rewritten():
+    """process_response should include retrieval_attempts=1 and
+    query_rewritten=False when CRAG did not rewrite (fixes #50)."""
+    response_data = {
+        "choices": [{"message": {"content": "Answer with no citations"}}],
+    }
+    ctx = {
+        "user_query": "test query",
+        "ranked": [],
+        "retrieved_set": set(),
+        "corpus_coverage": "none",
+        "crag": {
+            "retrieval_attempts": 1,
+            "query_rewritten": False,
+        },
+    }
+
+    result_data, _metadata = app.process_response(response_data, ctx)
+
+    assert "rag_metadata" in result_data
+    rag_meta = result_data["rag_metadata"]
+    assert rag_meta["retrieval_attempts"] == 1
+    assert rag_meta["query_rewritten"] is False
+
+
+def test_validate_streamed_response_includes_crag_fields():
+    """_validate_streamed_response should include CRAG fields in metadata
+    for streaming responses (fixes #50)."""
+    ctx = {
+        "user_query": "test query",
+        "ranked": [],
+        "retrieved_set": set(),
+        "corpus_coverage": "none",
+        "docstore": None,
+        "crag": {
+            "retrieval_attempts": 2,
+            "query_rewritten": True,
+            "original_query": "test query",
+            "rewritten_query": "improved query",
+        },
+    }
+
+    metadata = app._validate_streamed_response("Answer with no citations", ctx)
+
+    assert metadata is not None
+    assert metadata["retrieval_attempts"] == 2
+    assert metadata["query_rewritten"] is True
+    assert metadata["original_query"] == "test query"
+    assert metadata["rewritten_query"] == "improved query"


### PR DESCRIPTION
Closes #50

## Problem
ragpipe's CRAG implementation wrote `retrieval_attempts` and `query_rewritten` to query_log but streaming responses never sent these fields to the client. Non-streaming responses already included them in `rag_metadata`. ragorchestrator's ragpipe_tool.py reads these fields but always got defaults (1/False) on streaming.

## Solution
- Deferred `data: [DONE]` emission from `stream_response` to `validate_after_stream`
- After post-hoc citation validation, emit `rag_metadata` as a final SSE event before `[DONE]`
- Streaming clients now receive the same `retrieval_attempts`, `query_rewritten`, `original_query`, and `rewritten_query` fields that non-streaming clients already get

## Testing
174 tests passing (3 new):
- `test_process_response_includes_crag_fields_when_rewritten` — non-streaming with CRAG rewrite
- `test_process_response_includes_crag_fields_when_not_rewritten` — non-streaming without rewrite
- `test_validate_streamed_response_includes_crag_fields` — streaming metadata includes CRAG fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)