### PR TITLE
fix(infrastructure): pin ROCm Containerfile base image to digest (fixes #56)

### DIFF
--- a/Containerfile.rocm
+++ b/Containerfile.rocm
@@ -4,7 +4,7 @@
 # (same pattern as ragstuffer ROCm variant).
 # ROCm 7.2 required for gfx1151 (RDNA 3.5/4) support via gfx11-generic ISA.
 # For CPU-only builds, use the default Containerfile (UBI9/python-311).
-FROM docker.io/rocm/dev-ubuntu-24.04:7.2.1
+FROM docker.io/rocm/dev-ubuntu-24.04:7.2.1@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179
 
 # Install ROCm runtime libs needed by onnxruntime-migraphx's provider .so.
 # migraphx: libmigraphx_c.so (graph compiler)


### PR DESCRIPTION
Closes #56

## Change
Pins the ROCm Containerfile base image to a specific digest for supply chain security. The CPU Containerfile was already pinned; this adds the same protection to Containerfile.rocm.

Digest verified via skopeo: docker.io/rocm/dev-ubuntu-24.04:7.2.1 → sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179

Note: CodeRabbit noted that tag 7.2.1-complete also exists with a different digest (sha256:3db551c...). The 7.2.1 tag is the one previously used without a digest, so it's preserved here for consistency with prior usage.

## Testing
- skopeo inspect confirmed digest matches current tag
- hadolint passes on updated Containerfile