### PR TITLE
fix(infrastructure): add requests to dev dependencies (fixes #73)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "hypothesis"]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "hypothesis", "requests"]
 
 [project.scripts]
 ragpipe = "ragpipe.app:main"


### PR DESCRIPTION
Closes #73

## Change
Added  to the dev dependencies in pyproject.toml. The test_live.py file (from PR #70) imports requests but it was not listed in the dev dependencies, causing the CI to fail with .

## Testing
- ruff check: no issues