### PR TITLE
Add dependabot.yml (fixes #66)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Closes #66

## Problem
ragpipe is missing dependabot.yml for automated dependency updates.

## Solution
Add standard dependabot config with pip, docker, and github-actions ecosystems, matching the pattern used across all other rag-suite repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated weekly dependency updates for Python packages via pip, Docker images, and GitHub Actions. This ensures dependencies remain current and secure with minimal manual effort. Python package updates are strategically grouped by severity level, automatically combining minor and patch version changes into consolidated pull requests to significantly reduce review burden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->