### PR TITLE
feat(grounding): replace inline citation UUIDs with numbered footnotes (fixes #79)

### DIFF
--- a/ragpipe/app.py
+++ b/ragpipe/app.py
@@ -31,6 +31,8 @@ from ragpipe.grounding import (
     build_system_message,
     determine_corpus_coverage,
     format_context,
+    format_footnotes,
+    format_references_section,
     log_audit,
     parse_citations,
     query_hash,
@@ -783,6 +785,12 @@ def process_response(response_data: dict, ctx: dict) -> tuple[dict, dict]:
         metadata["retrieval_attempts"] = crag.get("retrieval_attempts", 1)
         metadata["query_rewritten"] = False
 
+    # Replace raw [doc_id:chunk_id] with numbered footnotes and append references
+    content, footnotes = format_footnotes(content, valid_citations, metadata.get("cited_chunks", []))
+    if footnotes:
+        response_data["choices"][0]["message"]["content"] = content
+        metadata["footnotes"] = footnotes
+
     # Attach metadata to the response
     response_data["rag_metadata"] = metadata
 
@@ -861,6 +869,11 @@ def _validate_streamed_response(content: str, ctx: dict) -> dict:
     else:
         metadata["retrieval_attempts"] = crag.get("retrieval_attempts", 1)
         metadata["query_rewritten"] = False
+
+    # Compute footnotes for streaming — references section will be appended by caller
+    _, footnotes = format_footnotes(content, valid_citations, metadata.get("cited_chunks", []))
+    if footnotes:
+        metadata["footnotes"] = footnotes
 
     log_audit(
         q_hash=query_hash(user_query),
@@ -1025,6 +1038,14 @@ async def chat_completions(request: Request):
             if full_content:
                 metadata = _validate_streamed_response(full_content, retrieval_ctx)
                 if metadata:
+                    # Emit references section as final content chunk before rag_metadata
+                    footnotes = metadata.get("footnotes", [])
+                    if footnotes:
+                        refs_text = format_references_section(footnotes)
+                        refs_chunk = {
+                            "choices": [{"delta": {"content": refs_text}, "index": 0, "finish_reason": None}],
+                        }
+                        yield f"data: {json.dumps(refs_chunk)}\n\n"
                     # Emit rag_metadata as SSE event before [DONE]
                     yield f"data: {json.dumps({'rag_metadata': metadata})}\n\n"
 

--- a/ragpipe/grounding.py
+++ b/ragpipe/grounding.py
@@ -390,6 +390,96 @@ def build_metadata(
     }
 
 
+# ── Footnote formatting ──────────────────────────────────────────────────────
+
+
+def format_footnotes(
+    content: str,
+    valid_citations: list[tuple[str, int]],
+    cited_chunks: list[dict],
+) -> tuple[str, list[dict]]:
+    """Replace [doc_id:chunk_id] markers with numbered footnotes and append references.
+
+    Args:
+        content: LLM response text with raw [doc_id:chunk_id] markers.
+        valid_citations: List of (doc_id, chunk_id) tuples that passed validation.
+        cited_chunks: Deduplicated list of {"id", "title", "source"} dicts from build_metadata.
+
+    Returns:
+        (rewritten_content, footnotes) where:
+        - rewritten_content has [N] instead of [doc_id:chunk_id] and a References section
+        - footnotes is a list of {"number", "doc_id", "chunk_id", "title", "source"} dicts
+    """
+    if not valid_citations or not cited_chunks:
+        return content, []
+
+    # Build a lookup from "doc_id:chunk_id" → chunk metadata
+    chunk_lookup: dict[str, dict] = {}
+    for chunk in cited_chunks:
+        chunk_lookup[chunk["id"]] = chunk
+
+    # Assign footnote numbers: deduplicate by (doc_id, chunk_id), preserve first-occurrence order
+    footnote_map: dict[str, int] = {}  # "doc_id:chunk_id" → footnote number
+    footnotes: list[dict] = []
+
+    for doc_id, chunk_id in valid_citations:
+        key = f"{doc_id}:{chunk_id}"
+        if key not in footnote_map:
+            num = len(footnotes) + 1
+            footnote_map[key] = num
+            meta = chunk_lookup.get(key, {})
+            footnotes.append(
+                {
+                    "number": num,
+                    "doc_id": doc_id,
+                    "chunk_id": chunk_id,
+                    "title": meta.get("title", ""),
+                    "source": meta.get("source", ""),
+                }
+            )
+
+    # Replace each [doc_id:chunk_id] in content with [N]
+    def _replace_citation(match):
+        doc_id = match.group(1)
+        chunk_id = int(match.group(2))
+        key = f"{doc_id}:{chunk_id}"
+        num = footnote_map.get(key)
+        if num is not None:
+            return f"[{num}]"
+        return match.group(0)  # Leave unrecognized citations as-is
+
+    rewritten = _CITATION_PATTERN.sub(_replace_citation, content)
+
+    # Append references section
+    if footnotes:
+        refs = "\n\n---\n**References**"
+        for fn in footnotes:
+            title = fn["title"] or "Untitled"
+            source = fn["source"] or ""
+            if source:
+                refs += f"\n{fn['number']}. {title} ({source})"
+            else:
+                refs += f"\n{fn['number']}. {title}"
+        rewritten += refs
+
+    return rewritten, footnotes
+
+
+def format_references_section(footnotes: list[dict]) -> str:
+    """Build just the references section text (for streaming append)."""
+    if not footnotes:
+        return ""
+    refs = "\n\n---\n**References**"
+    for fn in footnotes:
+        title = fn["title"] or "Untitled"
+        source = fn["source"] or ""
+        if source:
+            refs += f"\n{fn['number']}. {title} ({source})"
+        else:
+            refs += f"\n{fn['number']}. {title}"
+    return refs
+
+
 # ── Audit logging ────────────────────────────────────────────────────────────
 # Never logs query text, response text, or document content.
 # Only logs hashes, IDs, scores, and classification metadata.

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -360,6 +360,93 @@ def test_metadata_dedup_preserves_insertion_order():
     assert ids == ["b:1", "a:0", "c:3"]
 
 
+# ── Footnote formatting ──────────────────────────────────────────────────────
+
+
+def test_format_footnotes_basic():
+    """Footnotes replace raw UUIDs with [N] and append references."""
+    mod = _reload()
+    content = "Adam is an architect [abc-123:2]. He works at Red Hat [def-456:0]."
+    valid = [("abc-123", 2), ("def-456", 0)]
+    cited_chunks = [
+        {"id": "abc-123:2", "title": "Resume", "source": "gdrive://resume.pdf"},
+        {"id": "def-456:0", "title": "Org Chart", "source": "gdrive://org.pdf"},
+    ]
+    rewritten, footnotes = mod.format_footnotes(content, valid, cited_chunks)
+
+    assert "[1]" in rewritten
+    assert "[2]" in rewritten
+    assert "[abc-123:2]" not in rewritten
+    assert "---" in rewritten
+    assert "**References**" in rewritten
+    assert "1. Resume (gdrive://resume.pdf)" in rewritten
+    assert "2. Org Chart (gdrive://org.pdf)" in rewritten
+    assert len(footnotes) == 2
+    assert footnotes[0]["number"] == 1
+    assert footnotes[0]["doc_id"] == "abc-123"
+    assert footnotes[1]["number"] == 2
+
+
+def test_format_footnotes_deduplicates():
+    """Same doc_id:chunk_id appearing twice gets the same footnote number."""
+    mod = _reload()
+    content = "Fact A [abc:1]. Fact B [def:0]. Fact C [abc:1]."
+    valid = [("abc", 1), ("def", 0), ("abc", 1)]
+    cited_chunks = [
+        {"id": "abc:1", "title": "Doc A", "source": "s3://a"},
+        {"id": "def:0", "title": "Doc D", "source": "s3://d"},
+    ]
+    rewritten, footnotes = mod.format_footnotes(content, valid, cited_chunks)
+
+    # Two unique footnotes, not three
+    assert len(footnotes) == 2
+    # Both [abc:1] should become [1]
+    assert rewritten.count("[1]") == 2
+    assert rewritten.count("[2]") == 1
+
+
+def test_format_footnotes_empty():
+    """No citations returns content unchanged and empty footnotes."""
+    mod = _reload()
+    content = "No citations here."
+    rewritten, footnotes = mod.format_footnotes(content, [], [])
+    assert rewritten == content
+    assert footnotes == []
+
+
+def test_format_footnotes_preserves_unvalidated():
+    """Citations not in valid_citations are left as-is."""
+    mod = _reload()
+    content = "Valid [abc:1]. Invalid [xyz:9]."
+    valid = [("abc", 1)]
+    cited_chunks = [{"id": "abc:1", "title": "Doc", "source": "src"}]
+    rewritten, footnotes = mod.format_footnotes(content, valid, cited_chunks)
+
+    assert "[1]" in rewritten
+    assert "[xyz:9]" in rewritten  # Not in valid_citations, left alone
+    assert len(footnotes) == 1
+
+
+def test_format_references_section():
+    """format_references_section builds the references block."""
+    mod = _reload()
+    footnotes = [
+        {"number": 1, "doc_id": "a", "chunk_id": 0, "title": "Alpha", "source": "s://a"},
+        {"number": 2, "doc_id": "b", "chunk_id": 1, "title": "Beta", "source": "s://b"},
+    ]
+    refs = mod.format_references_section(footnotes)
+    assert "---" in refs
+    assert "**References**" in refs
+    assert "1. Alpha (s://a)" in refs
+    assert "2. Beta (s://b)" in refs
+
+
+def test_format_references_section_empty():
+    """No footnotes returns empty string."""
+    mod = _reload()
+    assert mod.format_references_section([]) == ""
+
+
 # ── Audit logging ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #79

## Problem
End users see raw `[133abba5-9eeb-5a99-8a5c-57e812c1ea83:2]` citation markers in responses — unreadable and ugly.

## Solution
Post-process LLM responses in ragpipe to replace raw `[doc_id:chunk_id]` markers with numbered `[N]` footnotes and append a References section.

### Non-streaming path (`process_response()`)
After citation validation, `format_footnotes()` rewrites the content:
- Assigns sequential footnote numbers (1, 2, 3...) to unique citations
- Replaces `[doc_id:chunk_id]` with `[N]` in the text
- Appends `---\n**References**\n1. Title (source)\n...`
- Deduplicates: same doc_id:chunk_id reuses the same footnote number

### Streaming path
References section emitted as a final content SSE chunk before `[DONE]`. Inline `[doc_id:chunk_id]` markers remain during streaming (can't rewrite in-flight) but the references section at the end maps them to titles.

### rag_metadata
New optional field (backward compatible):
```json
"footnotes": [
  {"number": 1, "doc_id": "abc-123", "chunk_id": 2, "title": "Resume", "source": "gdrive://resume.pdf"}
]
```

`cited_chunks` is unchanged.

## Testing
- 6 new tests in test_grounding.py (61 total pass):
  - `test_format_footnotes_basic` — UUID replacement + references
  - `test_format_footnotes_deduplicates` — same citation reuses number
  - `test_format_footnotes_empty` — no citations, no change
  - `test_format_footnotes_preserves_unvalidated` — invalid citations left as-is
  - `test_format_references_section` — references block format
  - `test_format_references_section_empty` — empty returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)