### PR TITLE
docs: update architecture SVGs for CRAG and current stack

### DIFF
--- a/architecture-components.svg
+++ b/architecture-components.svg
@@ -1,14 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 540" font-family="system-ui, -apple-system, sans-serif" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 600" font-family="system-ui, -apple-system, sans-serif" font-size="13">
   <style>
     @media (prefers-color-scheme: dark) {
       .bg { fill: #1a1a2e; }
       .box { fill: #16213e; stroke: #e2e8f0; }
       .box-highlight { fill: #1a365d; stroke: #63b3ed; }
       .box-test { fill: #1c2333; stroke: #9f7aea; }
+      .box-new { fill: #1f2d1f; stroke: #68d391; }
       .text { fill: #e2e8f0; }
       .text-dim { fill: #a0aec0; }
       .text-accent { fill: #63b3ed; }
       .text-purple { fill: #b794f4; }
+      .text-green { fill: #68d391; }
       .arrow { stroke: #63b3ed; fill: #63b3ed; }
       .arrow-dim { stroke: #4a5568; fill: #4a5568; }
       .label-bg { fill: #2d3748; }
@@ -18,10 +20,12 @@
       .box { fill: #f7fafc; stroke: #2d3748; }
       .box-highlight { fill: #ebf8ff; stroke: #3182ce; }
       .box-test { fill: #faf5ff; stroke: #805ad5; }
+      .box-new { fill: #f0fff4; stroke: #38a169; }
       .text { fill: #1a202c; }
       .text-dim { fill: #718096; }
       .text-accent { fill: #2b6cb0; }
       .text-purple { fill: #6b46c1; }
+      .text-green { fill: #276749; }
       .arrow { stroke: #3182ce; fill: #3182ce; }
       .arrow-dim { stroke: #a0aec0; fill: #a0aec0; }
       .label-bg { fill: #edf2f7; }
@@ -32,114 +36,138 @@
     <marker id="ahd" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow-dim"/></marker>
   </defs>
 
-  <rect width="900" height="540" class="bg" rx="8"/>
+  <rect width="920" height="600" class="bg" rx="8"/>
 
   <!-- Title -->
-  <text x="450" y="32" text-anchor="middle" font-size="18" font-weight="bold" class="text">ragpipe — component diagram</text>
-  <text x="450" y="50" text-anchor="middle" font-size="11" class="text-dim">Package internals and module relationships</text>
+  <text x="460" y="32" text-anchor="middle" font-size="18" font-weight="bold" class="text">ragpipe -- component diagram</text>
+  <text x="460" y="50" text-anchor="middle" font-size="11" class="text-dim">Package internals and module relationships</text>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
   <!-- APP.PY — central hub -->
-  <rect x="300" y="70" width="300" height="90" rx="6" class="box-highlight" stroke-width="2"/>
-  <text x="450" y="95" text-anchor="middle" font-weight="bold" font-size="14" class="text-accent">app.py</text>
-  <text x="450" y="113" text-anchor="middle" font-size="10" class="text-dim">FastAPI endpoints · request pipeline</text>
-  <text x="450" y="127" text-anchor="middle" font-size="10" class="text-dim">startup/shutdown · streaming · admin API</text>
-  <text x="450" y="141" text-anchor="middle" font-size="10" class="text-dim">retrieve_and_rerank() · process_response()</text>
+  <rect x="300" y="70" width="320" height="100" rx="6" class="box-highlight" stroke-width="2"/>
+  <text x="460" y="93" text-anchor="middle" font-weight="bold" font-size="14" class="text-accent">app.py</text>
+  <text x="460" y="111" text-anchor="middle" font-size="10" class="text-dim">FastAPI endpoints, request pipeline, admin API</text>
+  <text x="460" y="125" text-anchor="middle" font-size="10" class="text-dim">retrieve_and_rerank() with CRAG retry loop</text>
+  <text x="460" y="139" text-anchor="middle" font-size="10" class="text-dim">dual-path streaming, process_response()</text>
+  <text x="460" y="153" text-anchor="middle" font-size="10" class="text-dim">_rewrite_query() via LLM /nothink</text>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
-  <!-- LEFT COLUMN — routing + models -->
+  <!-- LEFT COLUMN -->
 
   <!-- ROUTER.PY -->
   <rect x="40" y="80" width="220" height="70" rx="5" class="box"/>
   <text x="150" y="103" text-anchor="middle" font-weight="600" font-size="12" class="text">router.py</text>
-  <text x="150" y="119" text-anchor="middle" font-size="10" class="text-dim">SemanticRouter · RouteConfig</text>
-  <text x="150" y="133" text-anchor="middle" font-size="10" class="text-dim">RoutePipeline · YAML loader</text>
+  <text x="150" y="119" text-anchor="middle" font-size="10" class="text-dim">SemanticRouter, RouteConfig</text>
+  <text x="150" y="133" text-anchor="middle" font-size="10" class="text-dim">RoutePipeline, YAML loader</text>
   <line x1="260" y1="115" x2="300" y2="115" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
 
   <!-- MODELS.PY -->
-  <rect x="40" y="195" width="220" height="70" rx="5" class="box"/>
-  <text x="150" y="218" text-anchor="middle" font-weight="600" font-size="12" class="text">models.py</text>
-  <text x="150" y="234" text-anchor="middle" font-size="10" class="text-dim">Embedder · Reranker</text>
-  <text x="150" y="248" text-anchor="middle" font-size="10" class="text-dim">ONNX Runtime · tokenizers · HF Hub</text>
-  <line x1="260" y1="220" x2="370" y2="160" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
+  <rect x="40" y="200" width="220" height="80" rx="5" class="box"/>
+  <text x="150" y="223" text-anchor="middle" font-weight="600" font-size="12" class="text">models.py</text>
+  <text x="150" y="239" text-anchor="middle" font-size="10" class="text-dim">Embedder, Reranker (ONNX Runtime)</text>
+  <text x="150" y="253" text-anchor="middle" font-size="10" class="text-dim">MIGraphX / CPU auto-detect</text>
+  <text x="150" y="267" text-anchor="middle" font-size="10" class="text-dim">HF Hub download, _is_gfx1151()</text>
+  <line x1="260" y1="230" x2="380" y2="170" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
 
-  <!-- Arrow: router uses models (via embedder) -->
-  <line x1="150" y1="150" x2="150" y2="195" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <text x="158" y="178" font-size="9" class="text-dim">embeds examples</text>
+  <!-- Arrow: router uses models -->
+  <line x1="150" y1="150" x2="150" y2="200" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
+  <text x="158" y="180" font-size="9" class="text-dim">embeds examples</text>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
-  <!-- RIGHT COLUMN — grounding + reranker -->
+  <!-- METRICS.PY (new) -->
+  <rect x="40" y="310" width="220" height="55" rx="5" class="box-new"/>
+  <text x="150" y="333" text-anchor="middle" font-weight="600" font-size="12" class="text">metrics.py</text>
+  <text x="150" y="349" text-anchor="middle" font-size="10" class="text-green">Prometheus counters, histograms</text>
+  <line x1="260" y1="335" x2="380" y2="170" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
+
+  <!-- RIGHT COLUMN -->
 
   <!-- GROUNDING.PY -->
-  <rect x="640" y="80" width="220" height="70" rx="5" class="box"/>
-  <text x="750" y="103" text-anchor="middle" font-weight="600" font-size="12" class="text">grounding.py</text>
-  <text x="750" y="119" text-anchor="middle" font-size="10" class="text-dim">SYSTEM_PROMPT · citations</text>
-  <text x="750" y="133" text-anchor="middle" font-size="10" class="text-dim">validation · classification · audit</text>
-  <line x1="600" y1="115" x2="640" y2="115" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <rect x="660" y="80" width="220" height="85" rx="5" class="box"/>
+  <text x="770" y="103" text-anchor="middle" font-weight="600" font-size="12" class="text">grounding.py</text>
+  <text x="770" y="119" text-anchor="middle" font-size="10" class="text-dim">SYSTEM_PROMPT (hot-reloadable)</text>
+  <text x="770" y="133" text-anchor="middle" font-size="10" class="text-dim">citation parsing + validation</text>
+  <text x="770" y="147" text-anchor="middle" font-size="10" class="text-dim">grounding classification, audit</text>
+  <line x1="620" y1="115" x2="660" y2="115" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
 
   <!-- RERANKER.PY -->
-  <rect x="640" y="195" width="220" height="70" rx="5" class="box"/>
-  <text x="750" y="218" text-anchor="middle" font-weight="600" font-size="12" class="text">reranker.py</text>
-  <text x="750" y="234" text-anchor="middle" font-size="10" class="text-dim">rerank() · min score filter</text>
-  <text x="750" y="248" text-anchor="middle" font-size="10" class="text-dim">wraps models.Reranker</text>
-  <line x1="640" y1="220" x2="530" y2="160" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
+  <rect x="660" y="200" width="220" height="70" rx="5" class="box"/>
+  <text x="770" y="223" text-anchor="middle" font-weight="600" font-size="12" class="text">reranker.py</text>
+  <text x="770" y="239" text-anchor="middle" font-size="10" class="text-dim">rerank(), min score filter</text>
+  <text x="770" y="253" text-anchor="middle" font-size="10" class="text-dim">wraps models.Reranker (CPU only)</text>
+  <line x1="660" y1="230" x2="540" y2="170" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
 
   <!-- Arrow: reranker uses models -->
-  <line x1="750" y1="265" x2="260" y2="240" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <text x="500" y="258" font-size="9" class="text-dim">uses Reranker</text>
+  <line x1="770" y1="270" x2="260" y2="250" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
+  <text x="510" y="265" font-size="9" class="text-dim">uses Reranker</text>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
   <!-- BOTTOM — docstore -->
-
-  <!-- DOCSTORE.PY -->
-  <rect x="300" y="195" width="300" height="70" rx="5" class="box"/>
-  <text x="450" y="218" text-anchor="middle" font-weight="600" font-size="12" class="text">docstore.py</text>
-  <text x="450" y="234" text-anchor="middle" font-size="10" class="text-dim">PostgresDocstore (asyncpg) · SQLiteDocstore</text>
-  <text x="450" y="248" text-anchor="middle" font-size="10" class="text-dim">CachedDocstore LRU wrapper · create_docstore()</text>
-  <line x1="450" y1="160" x2="450" y2="195" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <rect x="300" y="200" width="320" height="80" rx="5" class="box"/>
+  <text x="460" y="223" text-anchor="middle" font-weight="600" font-size="12" class="text">docstore.py</text>
+  <text x="460" y="239" text-anchor="middle" font-size="10" class="text-dim">PostgresDocstore (asyncpg), SQLiteDocstore</text>
+  <text x="460" y="253" text-anchor="middle" font-size="10" class="text-dim">CachedDocstore LRU wrapper, create_docstore()</text>
+  <text x="460" y="267" text-anchor="middle" font-size="10" class="text-dim">title hydration for citation v3 objects</text>
+  <line x1="460" y1="170" x2="460" y2="200" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
 
   <!-- Arrow: router creates per-route docstores -->
-  <line x1="200" y1="150" x2="300" y2="215" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <text x="225" y="185" font-size="9" class="text-dim">per-route</text>
+  <line x1="200" y1="150" x2="300" y2="220" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
+  <text x="225" y="190" font-size="9" class="text-dim">per-route</text>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
   <!-- ENTRY POINTS -->
-  <rect x="300" y="300" width="140" height="40" rx="4" class="label-bg"/>
-  <text x="370" y="318" text-anchor="middle" font-size="11" class="text">__main__.py</text>
-  <text x="370" y="332" text-anchor="middle" font-size="9" class="text-dim">python -m ragpipe</text>
+  <rect x="300" y="310" width="140" height="40" rx="4" class="label-bg"/>
+  <text x="370" y="328" text-anchor="middle" font-size="11" class="text">__main__.py</text>
+  <text x="370" y="342" text-anchor="middle" font-size="9" class="text-dim">python -m ragpipe</text>
 
-  <rect x="460" y="300" width="140" height="40" rx="4" class="label-bg"/>
-  <text x="530" y="318" text-anchor="middle" font-size="11" class="text">__init__.py</text>
-  <text x="530" y="332" text-anchor="middle" font-size="9" class="text-dim">__version__ · API</text>
+  <rect x="460" y="310" width="140" height="40" rx="4" class="label-bg"/>
+  <text x="530" y="328" text-anchor="middle" font-size="11" class="text">__init__.py</text>
+  <text x="530" y="342" text-anchor="middle" font-size="9" class="text-dim">__version__, API</text>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
   <!-- TESTS -->
-  <text x="450" y="375" text-anchor="middle" font-size="13" font-weight="bold" class="text-purple">tests/ — 97 tests</text>
+  <text x="460" y="388" text-anchor="middle" font-size="13" font-weight="bold" class="text-purple">tests/ -- 187 tests</text>
 
-  <rect x="40" y="395" width="155" height="50" rx="4" class="box-test"/>
-  <text x="117" y="416" text-anchor="middle" font-size="11" class="text">test_router.py</text>
-  <text x="117" y="432" text-anchor="middle" font-size="9" class="text-purple">14 tests</text>
+  <rect x="40" y="405" width="125" height="50" rx="4" class="box-test"/>
+  <text x="102" y="426" text-anchor="middle" font-size="10" class="text">test_router.py</text>
+  <text x="102" y="442" text-anchor="middle" font-size="9" class="text-purple">14 tests</text>
 
-  <rect x="210" y="395" width="155" height="50" rx="4" class="box-test"/>
-  <text x="287" y="416" text-anchor="middle" font-size="11" class="text">test_grounding.py</text>
-  <text x="287" y="432" text-anchor="middle" font-size="9" class="text-purple">36 tests</text>
+  <rect x="175" y="405" width="125" height="50" rx="4" class="box-test"/>
+  <text x="237" y="426" text-anchor="middle" font-size="10" class="text">test_grounding.py</text>
+  <text x="237" y="442" text-anchor="middle" font-size="9" class="text-purple">36 tests</text>
 
-  <rect x="380" y="395" width="155" height="50" rx="4" class="box-test"/>
-  <text x="457" y="416" text-anchor="middle" font-size="11" class="text">test_docstore.py</text>
-  <text x="457" y="432" text-anchor="middle" font-size="9" class="text-purple">25 tests</text>
+  <rect x="310" y="405" width="125" height="50" rx="4" class="box-test"/>
+  <text x="372" y="426" text-anchor="middle" font-size="10" class="text">test_docstore.py</text>
+  <text x="372" y="442" text-anchor="middle" font-size="9" class="text-purple">25 tests</text>
 
-  <rect x="550" y="395" width="155" height="50" rx="4" class="box-test"/>
-  <text x="627" y="416" text-anchor="middle" font-size="11" class="text">test_reranker.py</text>
-  <text x="627" y="432" text-anchor="middle" font-size="9" class="text-purple">12 tests</text>
+  <rect x="445" y="405" width="125" height="50" rx="4" class="box-test"/>
+  <text x="507" y="426" text-anchor="middle" font-size="10" class="text">test_reranker.py</text>
+  <text x="507" y="442" text-anchor="middle" font-size="9" class="text-purple">12 tests</text>
 
-  <rect x="720" y="395" width="145" height="50" rx="4" class="box-test"/>
-  <text x="792" y="416" text-anchor="middle" font-size="11" class="text">test_models.py</text>
-  <text x="792" y="432" text-anchor="middle" font-size="9" class="text-purple">7 tests</text>
+  <rect x="580" y="405" width="125" height="50" rx="4" class="box-test"/>
+  <text x="642" y="426" text-anchor="middle" font-size="10" class="text">test_models.py</text>
+  <text x="642" y="442" text-anchor="middle" font-size="9" class="text-purple">7 tests</text>
 
-  <rect x="380" y="455" width="155" height="50" rx="4" class="box-test"/>
-  <text x="457" y="476" text-anchor="middle" font-size="11" class="text">test_admin.py</text>
-  <text x="457" y="492" text-anchor="middle" font-size="9" class="text-purple">4 tests (+ classify)</text>
+  <rect x="715" y="405" width="125" height="50" rx="4" class="box-test"/>
+  <text x="777" y="426" text-anchor="middle" font-size="10" class="text">test_crag.py</text>
+  <text x="777" y="442" text-anchor="middle" font-size="9" class="text-purple">CRAG unit</text>
+
+  <rect x="40" y="465" width="125" height="50" rx="4" class="box-test"/>
+  <text x="102" y="486" text-anchor="middle" font-size="10" class="text">test_admin.py</text>
+  <text x="102" y="502" text-anchor="middle" font-size="9" class="text-purple">4 tests</text>
+
+  <rect x="175" y="465" width="125" height="50" rx="4" class="box-test"/>
+  <text x="237" y="486" text-anchor="middle" font-size="10" class="text">test_metrics.py</text>
+  <text x="237" y="502" text-anchor="middle" font-size="9" class="text-purple">Prometheus</text>
+
+  <rect x="310" y="465" width="125" height="50" rx="4" class="box-test"/>
+  <text x="372" y="486" text-anchor="middle" font-size="10" class="text">test_hypothesis.py</text>
+  <text x="372" y="502" text-anchor="middle" font-size="9" class="text-purple">property-based</text>
+
+  <rect x="445" y="465" width="125" height="50" rx="4" class="box-test"/>
+  <text x="507" y="486" text-anchor="middle" font-size="10" class="text">test_token_cap.py</text>
+  <text x="507" y="502" text-anchor="middle" font-size="9" class="text-purple">context limits</text>
+
+  <rect x="580" y="465" width="125" height="50" rx="4" class="box-test"/>
+  <text x="642" y="486" text-anchor="middle" font-size="10" class="text">test_qdrant_cache</text>
+  <text x="642" y="502" text-anchor="middle" font-size="9" class="text-purple">search cache</text>
 
   <!-- Footer -->
-  <text x="450" y="530" text-anchor="middle" font-size="10" class="text-dim">github.com/aclater/ragpipe · AGPL-3.0 · Python >=3.11 · UBI9 container</text>
+  <text x="460" y="545" text-anchor="middle" font-size="10" class="text-dim">New since last diagram: metrics.py, test_crag.py, test_metrics.py, test_hypothesis.py, test_token_cap.py, test_qdrant_cache.py</text>
+  <text x="460" y="562" text-anchor="middle" font-size="10" class="text-dim">CRAG retry in app.py | citation v3 objects in grounding.py | MXR cache in models.py</text>
+  <text x="460" y="582" text-anchor="middle" font-size="10" class="text-dim">github.com/aclater/ragpipe, AGPL-3.0, Python >=3.11, UBI9/UBI10 container</text>
 </svg>

--- a/architecture-routing.svg
+++ b/architecture-routing.svg
@@ -1,20 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 580" font-family="system-ui, -apple-system, sans-serif" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" font-family="system-ui, -apple-system, sans-serif" font-size="13">
   <style>
     @media (prefers-color-scheme: dark) {
       .bg { fill: #1a1a2e; }
       .box { fill: #16213e; stroke: #e2e8f0; }
       .box-highlight { fill: #1a365d; stroke: #63b3ed; }
       .box-external { fill: #1c1c1c; stroke: #718096; }
-      .box-host { fill: none; stroke: #4a5568; stroke-dasharray: 6,3; }
+      .box-future { fill: #1c1c1c; stroke: #718096; stroke-dasharray: 6,3; }
+      .box-collection { fill: #1f2d1f; stroke: #68d391; }
       .text { fill: #e2e8f0; }
       .text-dim { fill: #a0aec0; }
       .text-accent { fill: #63b3ed; }
       .text-green { fill: #68d391; }
       .text-orange { fill: #f6ad55; }
+      .text-pink { fill: #f687b3; }
+      .text-cyan { fill: #76e4f7; }
       .arrow { stroke: #63b3ed; fill: #63b3ed; }
       .arrow-dim { stroke: #718096; fill: #718096; }
       .arrow-green { stroke: #68d391; fill: #68d391; }
       .arrow-orange { stroke: #f6ad55; fill: #f6ad55; }
+      .arrow-pink { stroke: #f687b3; fill: #f687b3; }
+      .arrow-cyan { stroke: #76e4f7; fill: #76e4f7; }
       .label-bg { fill: #2d3748; }
     }
     @media (prefers-color-scheme: light) {
@@ -22,16 +27,21 @@
       .box { fill: #f7fafc; stroke: #2d3748; }
       .box-highlight { fill: #ebf8ff; stroke: #3182ce; }
       .box-external { fill: #f9f9f9; stroke: #a0aec0; }
-      .box-host { fill: none; stroke: #cbd5e0; stroke-dasharray: 6,3; }
+      .box-future { fill: #f9f9f9; stroke: #a0aec0; stroke-dasharray: 6,3; }
+      .box-collection { fill: #f0fff4; stroke: #38a169; }
       .text { fill: #1a202c; }
       .text-dim { fill: #718096; }
       .text-accent { fill: #2b6cb0; }
       .text-green { fill: #276749; }
       .text-orange { fill: #c05621; }
+      .text-pink { fill: #97266d; }
+      .text-cyan { fill: #0987a0; }
       .arrow { stroke: #3182ce; fill: #3182ce; }
       .arrow-dim { stroke: #a0aec0; fill: #a0aec0; }
       .arrow-green { stroke: #38a169; fill: #38a169; }
       .arrow-orange { stroke: #dd6b20; fill: #dd6b20; }
+      .arrow-pink { stroke: #d53f8c; fill: #d53f8c; }
+      .arrow-cyan { stroke: #0987a0; fill: #0987a0; }
       .label-bg { fill: #edf2f7; }
     }
   </style>
@@ -39,126 +49,141 @@
     <marker id="ah" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow"/></marker>
     <marker id="ahg" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow-green"/></marker>
     <marker id="aho" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow-orange"/></marker>
+    <marker id="ahp" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow-pink"/></marker>
+    <marker id="ahc" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow-cyan"/></marker>
     <marker id="ahd" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow-dim"/></marker>
   </defs>
 
-  <rect width="960" height="580" class="bg" rx="8"/>
+  <rect width="960" height="620" class="bg" rx="8"/>
 
   <!-- Title -->
-  <text x="480" y="32" text-anchor="middle" font-size="18" font-weight="bold" class="text">ragpipe — semantic routing</text>
-  <text x="480" y="50" text-anchor="middle" font-size="11" class="text-dim">Multi-LLM, multi-RAG, cross-host query routing with data classification isolation</text>
+  <text x="480" y="32" text-anchor="middle" font-size="18" font-weight="bold" class="text">ragpipe -- semantic routing</text>
+  <text x="480" y="50" text-anchor="middle" font-size="11" class="text-dim">4 collections with per-route LLM, Qdrant, docstore, and system prompt</text>
+
+  <!-- ragorchestrator (future) -->
+  <rect x="100" y="64" width="200" height="36" rx="6" class="box-future"/>
+  <text x="200" y="82" text-anchor="middle" font-size="11" class="text-dim">ragorchestrator :8095</text>
+  <text x="200" y="95" text-anchor="middle" font-size="9" class="text-dim">(agentic upstream)</text>
+  <line x1="300" y1="82" x2="370" y2="82" class="arrow-dim" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#ahd)"/>
 
   <!-- Client -->
   <rect x="380" y="64" width="200" height="36" rx="6" class="box-external"/>
   <text x="480" y="87" text-anchor="middle" font-weight="600" class="text">Client</text>
 
-  <!-- Arrow: Client → Router -->
+  <!-- Arrow: Client -> Router -->
   <line x1="480" y1="100" x2="480" y2="130" class="arrow" stroke-width="2" marker-end="url(#ah)"/>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
   <!-- RAGPIPE ROUTER -->
-  <rect x="300" y="134" width="360" height="70" rx="8" class="box-highlight" stroke-width="2" fill-opacity="0.4"/>
+  <rect x="280" y="134" width="400" height="80" rx="8" class="box-highlight" stroke-width="2" fill-opacity="0.4"/>
   <text x="480" y="158" text-anchor="middle" font-weight="bold" font-size="14" class="text-accent">Semantic Router</text>
-  <text x="480" y="176" text-anchor="middle" font-size="10" class="text-dim">cosine similarity on pre-embedded examples · &lt;1ms</text>
-  <text x="480" y="192" text-anchor="middle" font-size="10" class="text-dim">RAGPIPE_ROUTES_FILE · threshold · fallback route</text>
+  <text x="480" y="176" text-anchor="middle" font-size="10" class="text-dim">cosine similarity on pre-embedded examples, &lt;1ms</text>
+  <text x="480" y="192" text-anchor="middle" font-size="10" class="text-dim">RAGPIPE_ROUTES_FILE, hot-reload via POST /admin/reload-routes</text>
+  <text x="480" y="204" text-anchor="middle" font-size="10" class="text-dim">threshold-based, with fallback route</text>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
-  <!-- PRIMARY HOST BOX -->
-  <rect x="30" y="240" width="430" height="310" rx="8" class="box-host"/>
-  <text x="50" y="262" font-size="13" font-weight="bold" class="text-green">host-a (primary)</text>
-  <text x="50" y="278" font-size="10" class="text-dim">AMD Ryzen AI Max+ 395 · ROCm · 128 GB</text>
+  <!-- ════════════════════════════════════════ -->
+  <!-- 4 ROUTE COLUMNS -->
 
-  <!-- Analysis route -->
-  <rect x="55" y="295" width="185" height="68" rx="5" class="box"/>
-  <text x="147" y="316" text-anchor="middle" font-weight="600" font-size="12" class="text">analysis</text>
-  <text x="147" y="333" text-anchor="middle" font-size="10" class="text-dim">Qwen3.5-35B-A3B</text>
-  <text x="147" y="349" text-anchor="middle" font-size="10" class="text-dim">Complex queries · top_k=40</text>
+  <!-- Route: personnel -->
+  <rect x="30" y="260" width="210" height="230" rx="6" class="box"/>
+  <text x="135" y="282" text-anchor="middle" font-weight="bold" font-size="13" class="text-green">personnel</text>
+  <text x="135" y="300" text-anchor="middle" font-size="10" class="text-dim">PII-sensitive queries</text>
 
-  <!-- Personnel route -->
-  <rect x="255" y="295" width="185" height="68" rx="5" class="box"/>
-  <text x="347" y="316" text-anchor="middle" font-weight="600" font-size="12" class="text">personnel</text>
-  <text x="347" y="333" text-anchor="middle" font-size="10" class="text-dim">Qwen3.5-35B-A3B</text>
-  <text x="347" y="349" text-anchor="middle" font-size="10" class="text-dim">Data stays local · top_k=20</text>
+  <rect x="45" y="312" width="180" height="22" rx="3" class="box-collection"/>
+  <text x="135" y="327" text-anchor="middle" font-size="10" class="text-green">Qdrant: personnel</text>
 
-  <!-- Primary host services -->
-  <rect x="55" y="385" width="120" height="40" rx="4" class="box-external"/>
-  <text x="115" y="405" text-anchor="middle" font-size="11" class="text">Qdrant :6333</text>
-  <text x="115" y="418" text-anchor="middle" font-size="9" class="text-dim">documents</text>
+  <rect x="45" y="340" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="135" y="355" text-anchor="middle" font-size="10" class="text-dim">Postgres: personnel chunks</text>
 
-  <rect x="190" y="385" width="120" height="40" rx="4" class="box-external"/>
-  <text x="250" y="405" text-anchor="middle" font-size="11" class="text">Postgres :5432</text>
-  <text x="250" y="418" text-anchor="middle" font-size="9" class="text-dim">chunks</text>
+  <rect x="45" y="368" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="135" y="383" text-anchor="middle" font-size="10" class="text-dim">LLM :8080 Qwen3-32B</text>
 
-  <rect x="325" y="385" width="120" height="40" rx="4" class="box-external"/>
-  <text x="385" y="405" text-anchor="middle" font-size="11" class="text">LLM :8080</text>
-  <text x="385" y="418" text-anchor="middle" font-size="9" class="text-dim">35B-A3B · ROCm</text>
+  <rect x="45" y="396" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="135" y="411" text-anchor="middle" font-size="9" class="text-dim">top_k=20, min_score=-5</text>
 
-  <!-- Primary ragpipe label -->
-  <rect x="55" y="445" width="390" height="24" rx="3" class="label-bg"/>
-  <text x="250" y="461" text-anchor="middle" font-size="10" class="text-dim">ragpipe :8090 · embedder · reranker · chunk cache · asyncpg pool</text>
+  <rect x="45" y="424" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="135" y="439" text-anchor="middle" font-size="9" class="text-dim">data stays local</text>
 
-  <!-- Arrows: Router → primary routes -->
-  <line x1="420" y1="204" x2="147" y2="295" class="arrow-green" stroke-width="1.5" marker-end="url(#ahg)"/>
-  <line x1="480" y1="204" x2="347" y2="295" class="arrow-green" stroke-width="1.5" marker-end="url(#ahg)"/>
+  <text x="135" y="475" text-anchor="middle" font-size="10" class="text-green">F=1.000</text>
 
-  <!-- Arrows: Routes → Services -->
-  <line x1="147" y1="363" x2="115" y2="385" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <line x1="147" y1="363" x2="250" y2="385" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <line x1="147" y1="363" x2="385" y2="385" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <line x1="347" y1="363" x2="115" y2="385" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <line x1="347" y1="363" x2="250" y2="385" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <line x1="347" y1="363" x2="385" y2="385" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
+  <line x1="380" y1="214" x2="135" y2="260" class="arrow-green" stroke-width="1.5" marker-end="url(#ahg)"/>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
-  <!-- SECONDARY HOST BOX -->
-  <rect x="500" y="240" width="430" height="310" rx="8" class="box-host"/>
-  <text x="520" y="262" font-size="13" font-weight="bold" class="text-orange">host-b (secondary)</text>
-  <text x="520" y="278" font-size="10" class="text-dim">NVIDIA RTX 4070 Ti · CUDA · 125 GB</text>
+  <!-- Route: nato -->
+  <rect x="255" y="260" width="210" height="230" rx="6" class="box"/>
+  <text x="360" y="282" text-anchor="middle" font-weight="bold" font-size="13" class="text-orange">nato</text>
+  <text x="360" y="300" text-anchor="middle" font-size="10" class="text-dim">NATO/defense doctrine</text>
 
-  <!-- Lookup route -->
-  <rect x="525" y="295" width="185" height="68" rx="5" class="box"/>
-  <text x="617" y="316" text-anchor="middle" font-weight="600" font-size="12" class="text">lookup</text>
-  <text x="617" y="333" text-anchor="middle" font-size="10" class="text-dim">Qwen3.5-9B</text>
-  <text x="617" y="349" text-anchor="middle" font-size="10" class="text-dim">Fast factual · top_k=20</text>
+  <rect x="270" y="312" width="180" height="22" rx="3" class="box-collection"/>
+  <text x="360" y="327" text-anchor="middle" font-size="10" class="text-green">Qdrant: nato</text>
 
-  <!-- General route -->
-  <rect x="725" y="295" width="185" height="68" rx="5" class="box"/>
-  <text x="817" y="316" text-anchor="middle" font-weight="600" font-size="12" class="text">general</text>
-  <text x="817" y="333" text-anchor="middle" font-size="10" class="text-dim">Qwen3.5-9B</text>
-  <text x="817" y="349" text-anchor="middle" font-size="10" class="text-dim">No RAG · 380ms</text>
+  <rect x="270" y="340" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="360" y="355" text-anchor="middle" font-size="10" class="text-dim">Postgres: nato chunks</text>
 
-  <!-- Secondary host services -->
-  <rect x="525" y="385" width="120" height="40" rx="4" class="box-external"/>
-  <text x="585" y="405" text-anchor="middle" font-size="11" class="text">Qdrant :6333</text>
-  <text x="585" y="418" text-anchor="middle" font-size="9" class="text-dim">documents</text>
+  <rect x="270" y="368" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="360" y="383" text-anchor="middle" font-size="10" class="text-dim">LLM :8080 Qwen3-32B</text>
 
-  <rect x="660" y="385" width="120" height="40" rx="4" class="box-external"/>
-  <text x="720" y="405" text-anchor="middle" font-size="11" class="text">Postgres :5432</text>
-  <text x="720" y="418" text-anchor="middle" font-size="9" class="text-dim">chunks</text>
+  <rect x="270" y="396" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="360" y="411" text-anchor="middle" font-size="9" class="text-dim">top_k=40, min_score=-5</text>
 
-  <rect x="795" y="385" width="120" height="40" rx="4" class="box-external"/>
-  <text x="855" y="405" text-anchor="middle" font-size="11" class="text">LLM :8080</text>
-  <text x="855" y="418" text-anchor="middle" font-size="9" class="text-dim">9B · CUDA</text>
+  <rect x="270" y="424" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="360" y="439" text-anchor="middle" font-size="9" class="text-dim">complex analysis queries</text>
 
-  <!-- Secondary label -->
-  <rect x="525" y="445" width="390" height="24" rx="3" class="label-bg"/>
-  <text x="720" y="461" text-anchor="middle" font-size="10" class="text-dim">ragpipe :8090 · independent stack · same corpus (4,831 chunks)</text>
+  <line x1="430" y1="214" x2="360" y2="260" class="arrow-orange" stroke-width="1.5" marker-end="url(#aho)"/>
 
-  <!-- Arrows: Router → secondary routes -->
-  <line x1="540" y1="204" x2="617" y2="295" class="arrow-orange" stroke-width="1.5" marker-end="url(#aho)"/>
-  <line x1="580" y1="204" x2="817" y2="295" class="arrow-orange" stroke-width="1.5" marker-end="url(#aho)"/>
+  <!-- Route: mpep -->
+  <rect x="480" y="260" width="210" height="230" rx="6" class="box"/>
+  <text x="585" y="282" text-anchor="middle" font-weight="bold" font-size="13" class="text-pink">mpep</text>
+  <text x="585" y="300" text-anchor="middle" font-size="10" class="text-dim">USPTO patent examination</text>
 
-  <!-- Arrows: Lookup → Services -->
-  <line x1="617" y1="363" x2="585" y2="385" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <line x1="617" y1="363" x2="720" y2="385" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <line x1="617" y1="363" x2="855" y2="385" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
-  <!-- General → LLM only (no RAG) -->
-  <line x1="817" y1="363" x2="855" y2="385" class="arrow-dim" stroke-width="1" marker-end="url(#ahd)"/>
+  <rect x="495" y="312" width="180" height="22" rx="3" class="box-collection"/>
+  <text x="585" y="327" text-anchor="middle" font-size="10" class="text-green">Qdrant: mpep</text>
 
-  <!-- Network arrow between hosts -->
-  <text x="480" y="500" text-anchor="middle" font-size="10" class="text-dim">home network · all ports accessible</text>
+  <rect x="495" y="340" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="585" y="355" text-anchor="middle" font-size="10" class="text-dim">Postgres: mpep chunks</text>
+
+  <rect x="495" y="368" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="585" y="383" text-anchor="middle" font-size="10" class="text-dim">LLM :8080 Qwen3-32B</text>
+
+  <rect x="495" y="396" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="585" y="411" text-anchor="middle" font-size="9" class="text-dim">top_k=40, CRAG enabled</text>
+
+  <rect x="495" y="424" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="585" y="439" text-anchor="middle" font-size="9" class="text-dim">F: 0.333 -> 0.933 (CRAG)</text>
+
+  <text x="585" y="475" text-anchor="middle" font-size="10" class="text-pink">F=0.933 (post-CRAG)</text>
+
+  <line x1="530" y1="214" x2="585" y2="260" class="arrow-pink" stroke-width="1.5" marker-end="url(#ahp)"/>
+
+  <!-- Route: documents -->
+  <rect x="705" y="260" width="210" height="230" rx="6" class="box"/>
+  <text x="810" y="282" text-anchor="middle" font-weight="bold" font-size="13" class="text-cyan">documents</text>
+  <text x="810" y="300" text-anchor="middle" font-size="10" class="text-dim">General knowledge base</text>
+
+  <rect x="720" y="312" width="180" height="22" rx="3" class="box-collection"/>
+  <text x="810" y="327" text-anchor="middle" font-size="10" class="text-green">Qdrant: documents</text>
+
+  <rect x="720" y="340" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="810" y="355" text-anchor="middle" font-size="10" class="text-dim">Postgres: documents chunks</text>
+
+  <rect x="720" y="368" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="810" y="383" text-anchor="middle" font-size="10" class="text-dim">LLM :8080 Qwen3-32B</text>
+
+  <rect x="720" y="396" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="810" y="411" text-anchor="middle" font-size="9" class="text-dim">top_k=20, fallback route</text>
+
+  <rect x="720" y="424" width="180" height="22" rx="3" class="label-bg"/>
+  <text x="810" y="439" text-anchor="middle" font-size="9" class="text-dim">below-threshold queries land here</text>
+
+  <line x1="580" y1="214" x2="810" y2="260" class="arrow-cyan" stroke-width="1.5" marker-end="url(#ahc)"/>
+
+  <!-- ════════════════════════════════════════ -->
+  <!-- Shared infrastructure -->
+
+  <rect x="30" y="510" width="885" height="60" rx="6" class="label-bg"/>
+  <text x="480" y="530" text-anchor="middle" font-weight="600" font-size="12" class="text">Shared infrastructure</text>
+  <text x="480" y="548" text-anchor="middle" font-size="10" class="text-dim">Qdrant :6333 (4 collections) | Postgres :5432 (asyncpg, chunks+titles) | LLM :8080 (Qwen3-32B Q4_K_M, ~19GB GTT)</text>
+  <text x="480" y="562" text-anchor="middle" font-size="10" class="text-dim">ONNX Runtime embedder (gte-modernbert-base) + reranker (MiniLM-L-6-v2) | MXR cache (6s warm start) | ragwatch :9090</text>
 
   <!-- Footer -->
-  <text x="480" y="540" text-anchor="middle" font-size="11" class="text-dim">Classification runs on host-a (&lt;1ms) · forwarding via persistent httpx connection pool</text>
-  <text x="480" y="558" text-anchor="middle" font-size="10" class="text-dim">github.com/aclater/ragpipe · AGPL-3.0</text>
+  <text x="480" y="596" text-anchor="middle" font-size="11" class="text-dim">Classification &lt;1ms | CRAG retry on low confidence | citation v3: {id, title, source} | hot-reload routes without restart</text>
+  <text x="480" y="614" text-anchor="middle" font-size="10" class="text-dim">github.com/aclater/ragpipe, AGPL-3.0</text>
 </svg>

--- a/architecture.svg
+++ b/architecture.svg
@@ -1,16 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" font-family="system-ui, -apple-system, sans-serif" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 820" font-family="system-ui, -apple-system, sans-serif" font-size="13">
   <style>
     @media (prefers-color-scheme: dark) {
       .bg { fill: #1a1a2e; }
       .box { fill: #16213e; stroke: #e2e8f0; }
       .box-highlight { fill: #1a365d; stroke: #63b3ed; }
       .box-external { fill: #1c1c1c; stroke: #718096; }
+      .box-crag { fill: #2d1f3d; stroke: #b794f4; }
+      .box-future { fill: #1c1c1c; stroke: #718096; stroke-dasharray: 6,3; }
       .text { fill: #e2e8f0; }
       .text-dim { fill: #a0aec0; }
       .text-accent { fill: #63b3ed; }
       .text-warn { fill: #f6ad55; }
+      .text-purple { fill: #b794f4; }
+      .text-green { fill: #68d391; }
       .arrow { stroke: #63b3ed; fill: #63b3ed; }
       .arrow-dim { stroke: #718096; fill: #718096; }
+      .arrow-crag { stroke: #b794f4; fill: #b794f4; }
       .label-bg { fill: #2d3748; }
       .cache-bg { fill: #2d3748; stroke: #68d391; stroke-dasharray: 4,2; }
     }
@@ -19,12 +24,17 @@
       .box { fill: #f7fafc; stroke: #2d3748; }
       .box-highlight { fill: #ebf8ff; stroke: #3182ce; }
       .box-external { fill: #f9f9f9; stroke: #a0aec0; }
+      .box-crag { fill: #faf5ff; stroke: #805ad5; }
+      .box-future { fill: #f9f9f9; stroke: #a0aec0; stroke-dasharray: 6,3; }
       .text { fill: #1a202c; }
       .text-dim { fill: #718096; }
       .text-accent { fill: #2b6cb0; }
       .text-warn { fill: #c05621; }
+      .text-purple { fill: #6b46c1; }
+      .text-green { fill: #276749; }
       .arrow { stroke: #3182ce; fill: #3182ce; }
       .arrow-dim { stroke: #a0aec0; fill: #a0aec0; }
+      .arrow-crag { stroke: #805ad5; fill: #805ad5; }
       .label-bg { fill: #edf2f7; }
       .cache-bg { fill: #f0fff4; stroke: #38a169; stroke-dasharray: 4,2; }
     }
@@ -36,131 +46,199 @@
     <marker id="ahd" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
       <polygon points="0 0, 8 3, 0 6" class="arrow-dim"/>
     </marker>
+    <marker id="ahc" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" class="arrow-crag"/>
+    </marker>
   </defs>
 
-  <rect width="960" height="700" class="bg" rx="8"/>
+  <rect width="980" height="820" class="bg" rx="8"/>
 
   <!-- Title -->
-  <text x="480" y="32" text-anchor="middle" font-size="18" font-weight="bold" class="text">ragpipe — request flow</text>
-  <text x="480" y="50" text-anchor="middle" font-size="11" class="text-dim">RAG proxy with corpus-preferring grounding and citation validation</text>
+  <text x="490" y="32" text-anchor="middle" font-size="18" font-weight="bold" class="text">ragpipe -- request flow</text>
+  <text x="490" y="50" text-anchor="middle" font-size="11" class="text-dim">RAG proxy with CRAG corrective retrieval, dual-path streaming, and citation validation</text>
+
+  <!-- ragorchestrator (future upstream) -->
+  <rect x="130" y="64" width="200" height="36" rx="6" class="box-future"/>
+  <text x="230" y="82" text-anchor="middle" font-size="11" class="text-dim">ragorchestrator :8095</text>
+  <text x="230" y="95" text-anchor="middle" font-size="9" class="text-dim">(agentic upstream)</text>
+  <line x1="330" y1="82" x2="380" y2="82" class="arrow-dim" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#ahd)"/>
 
   <!-- Client -->
-  <rect x="370" y="64" width="220" height="36" rx="6" class="box-external"/>
-  <text x="480" y="87" text-anchor="middle" font-weight="600" class="text">Client</text>
-  <text x="480" y="87" text-anchor="middle" font-size="10" class="text-dim" dy="14">curl / Open WebUI / SDK</text>
+  <rect x="390" y="64" width="200" height="36" rx="6" class="box-external"/>
+  <text x="490" y="82" text-anchor="middle" font-weight="600" class="text">Client</text>
+  <text x="490" y="95" text-anchor="middle" font-size="9" class="text-dim">Open WebUI / SDK / curl</text>
 
-  <!-- Arrow: Client → ragpipe -->
-  <line x1="480" y1="100" x2="480" y2="126" class="arrow" stroke-width="2" marker-end="url(#ah)"/>
-  <text x="490" y="118" font-size="10" class="text-dim">POST /v1/chat/completions</text>
+  <!-- Arrow: Client -> ragpipe -->
+  <line x1="490" y1="100" x2="490" y2="128" class="arrow" stroke-width="2" marker-end="url(#ah)"/>
+  <text x="560" y="120" font-size="10" class="text-dim">POST /v1/chat/completions</text>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
   <!-- RAGPIPE BOX -->
-  <rect x="30" y="130" width="900" height="440" rx="8" class="box-highlight" stroke-width="2" fill-opacity="0.3"/>
-  <text x="50" y="154" font-size="15" font-weight="bold" class="text-accent">ragpipe :8090</text>
+  <rect x="30" y="132" width="920" height="555" rx="8" class="box-highlight" stroke-width="2" fill-opacity="0.3"/>
+  <text x="50" y="156" font-size="15" font-weight="bold" class="text-accent">ragpipe :8090</text>
 
-  <!-- Step 1: Embed -->
-  <rect x="55" y="170" width="190" height="48" rx="5" class="box"/>
-  <text x="150" y="191" text-anchor="middle" font-weight="600" font-size="12" class="text">1. Embed query</text>
-  <text x="150" y="208" text-anchor="middle" font-size="10" class="text-dim">ONNX Runtime · bge-base-en-v1.5</text>
+  <!-- Step 1: Semantic Router -->
+  <rect x="55" y="170" width="200" height="48" rx="5" class="box"/>
+  <text x="155" y="191" text-anchor="middle" font-weight="600" font-size="12" class="text">1. Semantic router</text>
+  <text x="155" y="208" text-anchor="middle" font-size="10" class="text-dim">cosine similarity, &lt;1ms</text>
+
+  <!-- Collections label -->
+  <rect x="270" y="172" width="200" height="44" rx="3" class="label-bg"/>
+  <text x="370" y="188" text-anchor="middle" font-size="9" class="text-accent">personnel | nato | mpep | documents</text>
+  <text x="370" y="202" text-anchor="middle" font-size="9" class="text-dim">per-route: LLM, Qdrant, docstore, prompt</text>
+  <line x1="255" y1="194" x2="270" y2="194" class="arrow-dim" stroke-width="1" stroke-dasharray="3,2"/>
+
+  <!-- Step 2: Embed query -->
+  <rect x="55" y="232" width="200" height="48" rx="5" class="box"/>
+  <text x="155" y="253" text-anchor="middle" font-weight="600" font-size="12" class="text">2. Embed query</text>
+  <text x="155" y="270" text-anchor="middle" font-size="10" class="text-dim">ONNX Runtime, gte-modernbert-base</text>
 
   <!-- Embed cache -->
-  <rect x="260" y="174" width="80" height="20" rx="3" class="cache-bg"/>
-  <text x="300" y="188" text-anchor="middle" font-size="9" class="text-accent">LRU (256)</text>
-  <line x1="245" y1="188" x2="260" y2="188" class="arrow-dim" stroke-width="1" stroke-dasharray="3,2"/>
+  <rect x="270" y="236" width="80" height="20" rx="3" class="cache-bg"/>
+  <text x="310" y="250" text-anchor="middle" font-size="9" class="text-accent">LRU (256)</text>
+  <line x1="255" y1="250" x2="270" y2="250" class="arrow-dim" stroke-width="1" stroke-dasharray="3,2"/>
 
-  <!-- Step 2: Search Qdrant -->
-  <rect x="55" y="232" width="190" height="48" rx="5" class="box"/>
-  <text x="150" y="253" text-anchor="middle" font-weight="600" font-size="12" class="text">2. Vector search</text>
-  <text x="150" y="270" text-anchor="middle" font-size="10" class="text-dim">Qdrant · top-K candidates</text>
+  <!-- MXR cache label -->
+  <rect x="270" y="260" width="120" height="18" rx="3" class="cache-bg"/>
+  <text x="330" y="273" text-anchor="middle" font-size="8" class="text-green">MXR cache (6s warm)</text>
 
-  <!-- Step 3: Hydrate -->
-  <rect x="55" y="294" width="190" height="48" rx="5" class="box"/>
-  <text x="150" y="315" text-anchor="middle" font-weight="600" font-size="12" class="text">3. Hydrate chunks</text>
-  <text x="150" y="332" text-anchor="middle" font-size="10" class="text-dim">asyncpg pool · native async</text>
+  <!-- Step 3: Search Qdrant -->
+  <rect x="55" y="294" width="200" height="48" rx="5" class="box"/>
+  <text x="155" y="315" text-anchor="middle" font-weight="600" font-size="12" class="text">3. Vector search</text>
+  <text x="155" y="332" text-anchor="middle" font-size="10" class="text-dim">Qdrant, top-K candidates</text>
+
+  <!-- Step 4: Hydrate -->
+  <rect x="55" y="356" width="200" height="48" rx="5" class="box"/>
+  <text x="155" y="377" text-anchor="middle" font-weight="600" font-size="12" class="text">4. Hydrate chunks</text>
+  <text x="155" y="394" text-anchor="middle" font-size="10" class="text-dim">asyncpg pool, titles + text</text>
 
   <!-- Chunk cache -->
-  <rect x="260" y="298" width="95" height="20" rx="3" class="cache-bg"/>
-  <text x="307" y="312" text-anchor="middle" font-size="9" class="text-accent">LRU (2,048)</text>
-  <line x1="245" y1="312" x2="260" y2="312" class="arrow-dim" stroke-width="1" stroke-dasharray="3,2"/>
+  <rect x="270" y="360" width="100" height="20" rx="3" class="cache-bg"/>
+  <text x="320" y="374" text-anchor="middle" font-size="9" class="text-accent">LRU (2,048)</text>
+  <line x1="255" y1="374" x2="270" y2="374" class="arrow-dim" stroke-width="1" stroke-dasharray="3,2"/>
 
-  <!-- Step 4: Rerank + filter -->
-  <rect x="55" y="356" width="190" height="48" rx="5" class="box"/>
-  <text x="150" y="377" text-anchor="middle" font-weight="600" font-size="12" class="text">4. Rerank + filter</text>
-  <text x="150" y="394" text-anchor="middle" font-size="10" class="text-dim">MiniLM-L-6 · min_score=-5</text>
-
-  <!-- Step 5: Inject context -->
-  <rect x="55" y="418" width="190" height="48" rx="5" class="box"/>
-  <text x="150" y="439" text-anchor="middle" font-weight="600" font-size="12" class="text">5. Inject context</text>
-  <text x="150" y="456" text-anchor="middle" font-size="10" class="text-dim">system prompt + [doc:chunk]</text>
+  <!-- Step 5: Rerank + filter -->
+  <rect x="55" y="418" width="200" height="48" rx="5" class="box"/>
+  <text x="155" y="439" text-anchor="middle" font-weight="600" font-size="12" class="text">5. Rerank + filter</text>
+  <text x="155" y="456" text-anchor="middle" font-size="10" class="text-dim">MiniLM-L-6-v2, min_score=-5</text>
 
   <!-- Arrows between left column steps -->
-  <line x1="150" y1="218" x2="150" y2="232" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <line x1="150" y1="280" x2="150" y2="294" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <line x1="150" y1="342" x2="150" y2="356" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <line x1="150" y1="404" x2="150" y2="418" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <line x1="155" y1="218" x2="155" y2="232" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <line x1="155" y1="280" x2="155" y2="294" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <line x1="155" y1="342" x2="155" y2="356" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <line x1="155" y1="404" x2="155" y2="418" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
 
-  <!-- Arrow: Inject → Forward -->
-  <line x1="245" y1="442" x2="395" y2="442" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <!-- ════════════════════════════════════════════════ -->
+  <!-- CRAG retry loop -->
+  <rect x="280" y="418" width="220" height="80" rx="5" class="box-crag"/>
+  <text x="390" y="438" text-anchor="middle" font-weight="600" font-size="12" class="text-purple">CRAG retry</text>
+  <text x="390" y="455" text-anchor="middle" font-size="10" class="text-dim">if reranking filters all chunks:</text>
+  <text x="390" y="470" text-anchor="middle" font-size="10" class="text-purple">rewrite query via LLM (/nothink)</text>
+  <text x="390" y="485" text-anchor="middle" font-size="10" class="text-purple">re-embed, re-search, re-rerank</text>
 
-  <!-- Step 6: Forward to LLM -->
-  <rect x="400" y="418" width="190" height="48" rx="5" class="box"/>
-  <text x="495" y="439" text-anchor="middle" font-weight="600" font-size="12" class="text">6. Forward to LLM</text>
-  <text x="495" y="456" text-anchor="middle" font-size="10" class="text-dim">persistent httpx client</text>
+  <!-- Arrow: Rerank -> CRAG (conditional) -->
+  <line x1="255" y1="442" x2="280" y2="442" class="arrow-crag" stroke-width="1.5" marker-end="url(#ahc)"/>
+  <text x="268" y="434" font-size="8" class="text-purple">low</text>
+  <text x="262" y="454" font-size="8" class="text-purple">confidence</text>
 
-  <!-- Arrow: Forward → Post-process -->
-  <line x1="590" y1="442" x2="660" y2="442" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <!-- Arrow: CRAG loops back to step 2 -->
+  <path d="M 500 458 L 530 458 L 530 253 L 255 253" class="arrow-crag" stroke-width="1.5" fill="none" marker-end="url(#ahc)"/>
+  <text x="540" y="360" font-size="9" class="text-purple" transform="rotate(-90,540,360)">re-retrieve</text>
 
-  <!-- Step 7: Post-process -->
-  <rect x="665" y="356" width="240" height="120" rx="5" class="box"/>
-  <text x="785" y="377" text-anchor="middle" font-weight="600" font-size="12" class="text">7. Post-process</text>
-  <text x="785" y="397" text-anchor="middle" font-size="10" class="text-dim">Parse [doc_id:chunk_id]</text>
-  <text x="785" y="413" text-anchor="middle" font-size="10" class="text-dim">Validate vs retrieved set</text>
-  <text x="785" y="429" text-anchor="middle" font-size="10" class="text-dim">Strip invalid citations</text>
-  <text x="785" y="445" text-anchor="middle" font-size="10" class="text-dim">Classify: corpus/general/mixed</text>
-  <text x="785" y="461" text-anchor="middle" font-size="10" class="text-dim">Attach rag_metadata + audit</text>
+  <!-- ════════════════════════════════════════════════ -->
+  <!-- Step 6: Inject context -->
+  <rect x="55" y="480" width="200" height="48" rx="5" class="box"/>
+  <text x="155" y="501" text-anchor="middle" font-weight="600" font-size="12" class="text">6. Inject context</text>
+  <text x="155" y="518" text-anchor="middle" font-size="10" class="text-dim">system prompt + [doc_id:chunk_id]</text>
 
-  <!-- ══════════════════════════════════════════════════════════ -->
+  <!-- Arrow: Rerank -> Inject (normal path) -->
+  <line x1="155" y1="466" x2="155" y2="480" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+
+  <!-- Arrow: Inject -> Forward -->
+  <line x1="255" y1="504" x2="540" y2="504" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+
+  <!-- Step 7: Forward to LLM -->
+  <rect x="545" y="480" width="190" height="48" rx="5" class="box"/>
+  <text x="640" y="501" text-anchor="middle" font-weight="600" font-size="12" class="text">7. Forward to LLM</text>
+  <text x="640" y="518" text-anchor="middle" font-size="10" class="text-dim">persistent httpx client</text>
+
+  <!-- Streaming split -->
+  <rect x="545" y="540" width="190" height="40" rx="4" class="label-bg"/>
+  <text x="640" y="555" text-anchor="middle" font-size="10" class="text-accent">dual-path streaming</text>
+  <text x="640" y="568" text-anchor="middle" font-size="9" class="text-dim">SSE to client + accumulate for audit</text>
+  <line x1="640" y1="528" x2="640" y2="540" class="arrow" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- Arrow: Forward -> Post-process -->
+  <line x1="735" y1="504" x2="760" y2="504" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+
+  <!-- Step 8: Post-process -->
+  <rect x="765" y="408" width="170" height="140" rx="5" class="box"/>
+  <text x="850" y="428" text-anchor="middle" font-weight="600" font-size="12" class="text">8. Post-process</text>
+  <text x="850" y="448" text-anchor="middle" font-size="10" class="text-dim">Parse [doc_id:chunk_id]</text>
+  <text x="850" y="463" text-anchor="middle" font-size="10" class="text-dim">Validate vs retrieved set</text>
+  <text x="850" y="478" text-anchor="middle" font-size="10" class="text-dim">Strip invalid citations</text>
+  <text x="850" y="493" text-anchor="middle" font-size="10" class="text-dim">Classify: corpus/general/mixed</text>
+  <text x="850" y="508" text-anchor="middle" font-size="10" class="text-dim">Negative finding detection</text>
+  <text x="850" y="523" text-anchor="middle" font-size="10" class="text-dim">Attach rag_metadata v3</text>
+  <text x="850" y="538" text-anchor="middle" font-size="10" class="text-dim">cited_chunks: {id,title,source}</text>
+
+  <!-- ════════════════════════════════════════════════ -->
   <!-- External services -->
 
   <!-- Qdrant -->
-  <rect x="740" y="170" width="150" height="48" rx="5" class="box-external"/>
-  <text x="815" y="191" text-anchor="middle" font-weight="600" font-size="12" class="text">Qdrant</text>
-  <text x="815" y="208" text-anchor="middle" font-size="10" class="text-dim">:6333 · vectors only</text>
-  <line x1="245" y1="256" x2="740" y2="198" class="arrow-dim" stroke-width="1.5" marker-end="url(#ahd)"/>
+  <rect x="770" y="170" width="160" height="48" rx="5" class="box-external"/>
+  <text x="850" y="191" text-anchor="middle" font-weight="600" font-size="12" class="text">Qdrant</text>
+  <text x="850" y="208" text-anchor="middle" font-size="10" class="text-dim">:6333, vectors only</text>
+  <line x1="255" y1="318" x2="770" y2="198" class="arrow-dim" stroke-width="1.5" marker-end="url(#ahd)"/>
 
   <!-- Postgres -->
-  <rect x="740" y="240" width="150" height="48" rx="5" class="box-external"/>
-  <text x="815" y="261" text-anchor="middle" font-weight="600" font-size="12" class="text">Postgres</text>
-  <text x="815" y="278" text-anchor="middle" font-size="10" class="text-dim">:5432 · asyncpg pool</text>
-  <line x1="245" y1="318" x2="740" y2="268" class="arrow-dim" stroke-width="1.5" marker-end="url(#ahd)"/>
+  <rect x="770" y="240" width="160" height="48" rx="5" class="box-external"/>
+  <text x="850" y="261" text-anchor="middle" font-weight="600" font-size="12" class="text">Postgres</text>
+  <text x="850" y="278" text-anchor="middle" font-size="10" class="text-dim">:5432, chunks + titles</text>
+  <line x1="255" y1="380" x2="770" y2="268" class="arrow-dim" stroke-width="1.5" marker-end="url(#ahd)"/>
 
   <!-- LLM -->
-  <rect x="400" y="500" width="190" height="48" rx="5" class="box-external"/>
-  <text x="495" y="521" text-anchor="middle" font-weight="600" font-size="12" class="text">LLM</text>
-  <text x="495" y="538" text-anchor="middle" font-size="10" class="text-dim">:8080 · llama-server</text>
-  <line x1="495" y1="466" x2="495" y2="500" class="arrow-dim" stroke-width="1.5" marker-end="url(#ahd)"/>
+  <rect x="545" y="594" width="190" height="48" rx="5" class="box-external"/>
+  <text x="640" y="615" text-anchor="middle" font-weight="600" font-size="12" class="text">LLM (Qwen3-32B)</text>
+  <text x="640" y="632" text-anchor="middle" font-size="10" class="text-dim">:8080, Q4_K_M, ~19GB GTT</text>
+  <line x1="640" y1="580" x2="640" y2="594" class="arrow-dim" stroke-width="1.5" marker-end="url(#ahd)"/>
 
-  <!-- Admin endpoint -->
-  <rect x="55" y="490" width="190" height="48" rx="5" class="box"/>
-  <text x="150" y="511" text-anchor="middle" font-weight="600" font-size="12" class="text">Admin API</text>
-  <text x="150" y="528" text-anchor="middle" font-size="10" class="text-dim">POST /admin/reload-prompt</text>
+  <!-- Prometheus / ragwatch -->
+  <rect x="55" y="594" width="180" height="40" rx="5" class="box-external"/>
+  <text x="145" y="612" text-anchor="middle" font-size="11" class="text">ragwatch :9090</text>
+  <text x="145" y="626" text-anchor="middle" font-size="9" class="text-dim">Prometheus metrics</text>
 
-  <!-- Prompt file -->
-  <rect x="260" y="494" width="110" height="20" rx="3" class="label-bg"/>
-  <text x="315" y="508" text-anchor="middle" font-size="9" class="text-dim">prompt file (hot-reload)</text>
-  <line x1="245" y1="514" x2="260" y2="508" class="arrow-dim" stroke-width="1" stroke-dasharray="3,2"/>
+  <!-- Admin endpoints -->
+  <rect x="260" y="594" width="240" height="40" rx="5" class="box"/>
+  <text x="380" y="612" text-anchor="middle" font-weight="600" font-size="11" class="text">Admin API</text>
+  <text x="380" y="626" text-anchor="middle" font-size="9" class="text-dim">POST /admin/reload-routes | reload-prompt</text>
 
   <!-- Response arrow back up -->
-  <line x1="785" y1="356" x2="785" y2="130" class="arrow" stroke-width="1.5"/>
-  <line x1="785" y1="130" x2="510" y2="100" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <text x="800" y="150" font-size="10" class="text-dim">Response + rag_metadata</text>
+  <line x1="850" y1="408" x2="850" y2="135" class="arrow" stroke-width="1.5"/>
+  <line x1="850" y1="135" x2="520" y2="100" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <text x="870" y="155" font-size="10" class="text-dim">Response + rag_metadata</text>
 
   <!-- Thread pool indicator -->
-  <rect x="55" y="548" width="300" height="16" rx="3" class="label-bg"/>
-  <text x="205" y="560" text-anchor="middle" font-size="9" class="text-dim">ThreadPoolExecutor (4 workers) · embed + rerank | asyncpg · hydrate</text>
+  <rect x="55" y="650" width="340" height="16" rx="3" class="label-bg"/>
+  <text x="225" y="662" text-anchor="middle" font-size="9" class="text-dim">ThreadPoolExecutor (4 workers): embed + rerank | asyncpg: hydrate (native async)</text>
 
-  <!-- Footer: specs -->
-  <text x="480" y="600" text-anchor="middle" font-size="11" class="text-dim">ONNX Runtime (CPU) · 708 MB RSS · 4 threads/model · embed cache (256) · chunk cache (2,048)</text>
-  <text x="480" y="618" text-anchor="middle" font-size="11" class="text-dim">asyncpg pool (2-8) · persistent httpx · reranker min_score=-5 · hot-reloadable prompt</text>
-  <text x="480" y="640" text-anchor="middle" font-size="10" class="text-dim">github.com/aclater/ragpipe · AGPL-3.0</text>
+  <!-- Footer -->
+  <text x="490" y="700" text-anchor="middle" font-size="11" class="text-dim">ONNX Runtime (CPU on gfx1151 / MIGraphX on dGPU) | asyncpg pool (2-8) | persistent httpx | hot-reloadable prompt + routes</text>
+  <text x="490" y="718" text-anchor="middle" font-size="11" class="text-dim">Citation v3: cited_chunks as {id, title, source} objects | Grounding: corpus/general/mixed with negative finding detection</text>
+  <text x="490" y="740" text-anchor="middle" font-size="10" class="text-dim">github.com/aclater/ragpipe, AGPL-3.0</text>
+
+  <!-- Legend -->
+  <rect x="55" y="756" width="350" height="52" rx="4" class="label-bg"/>
+  <text x="70" y="772" font-size="10" font-weight="600" class="text">Legend:</text>
+  <line x1="120" y1="769" x2="150" y2="769" class="arrow" stroke-width="2"/>
+  <text x="155" y="773" font-size="9" class="text-dim">data flow</text>
+  <line x1="210" y1="769" x2="240" y2="769" class="arrow-crag" stroke-width="2"/>
+  <text x="245" y="773" font-size="9" class="text-purple">CRAG retry</text>
+  <line x1="310" y1="769" x2="340" y2="769" class="arrow-dim" stroke-width="2" stroke-dasharray="4,3"/>
+  <text x="345" y="773" font-size="9" class="text-dim">future</text>
+  <rect x="70" y="780" width="14" height="14" rx="2" class="cache-bg"/>
+  <text x="90" y="792" font-size="9" class="text-green">cache layer</text>
+  <rect x="165" y="780" width="14" height="14" rx="2" class="box-crag"/>
+  <text x="185" y="792" font-size="9" class="text-purple">corrective RAG</text>
+  <rect x="280" y="780" width="14" height="14" rx="2" class="box-external"/>
+  <text x="300" y="792" font-size="9" class="text-dim">external service</text>
 </svg>


### PR DESCRIPTION
## Summary

- Updated all three architecture SVGs (`architecture.svg`, `architecture-components.svg`, `architecture-routing.svg`) to reflect the current ragpipe state
- Added CRAG corrective retrieval loop (rewrite query via LLM /nothink on low confidence, re-retrieve)
- Updated to citation v3 format (`{id, title, source}` objects)
- Added dual-path streaming with post-hoc validation
- Updated model references to Qwen3-32B Q4_K_M
- Added MXR cache layer, Prometheus metrics integration, ragorchestrator as future upstream
- Dark/light mode compatible via `prefers-color-scheme` media queries
- Updated test counts (187 tests) and new modules (metrics.py, test_crag.py, etc.)
- Shows all 4 Qdrant collections with per-route configuration and Ragas faithfulness scores

## Test plan

- [x] All 187 tests pass (`pytest tests/ -q --ignore=tests/test_live.py --ignore=tests/test_integration_crag.py`)
- [ ] Visually verify SVGs render correctly on GitHub in both dark and light mode
- [ ] Confirm no stale model names or citation formats remain

Closes #77

Generated with [Claude Code](https://claude.com/claude-code)