### PR TITLE
fix(ci): make SBOM attestation non-blocking

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Attest SBOM
         if: github.event_name != 'pull_request'
+        continue-on-error: true  # ROCm SBOM exceeds 16 MiB attestation limit (#65)
         uses: actions/attest@v4.1.0
         id: attest
         with:


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the `actions/attest@v4.1.0` step in `container.yml`
- The ROCm image SBOM exceeds the 16 MiB attestation predicate size limit, which was failing the entire Build & push job and preventing images from being published to ghcr.io

Closes #65

## Test plan

- [ ] Merge and verify the next `main` push successfully publishes both CPU and ROCm images to ghcr.io
- [ ] Confirm the Attest SBOM step shows as a non-fatal warning (not a failure) for the ROCm variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved CI/CD pipeline resilience to prevent workflow interruptions during build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->