### PR TITLE
Fix purple triangle artifact in architecture.svg (fixes #85)

### DIFF
--- a/architecture.svg
+++ b/architecture.svg
@@ -141,7 +141,7 @@
   <text x="262" y="454" font-size="8" class="text-purple">confidence</text>
 
   <!-- Arrow: CRAG loops back to step 2 -->
-  <path d="M 500 458 L 530 458 L 530 253 L 255 253" class="arrow-crag" stroke-width="1.5" fill="none" marker-end="url(#ahc)"/>
+  <path d="M 500 458 L 530 458 L 530 253 L 255 253" class="arrow-crag" stroke-width="1.5" style="fill:none" marker-end="url(#ahc)"/>
   <text x="540" y="360" font-size="9" class="text-purple" transform="rotate(-90,540,360)">re-retrieve</text>
 
   <!-- ════════════════════════════════════════════════ -->


### PR DESCRIPTION
Closes #85

## Problem
Large purple triangle rendering artifact in `architecture.svg` on GitHub.

## Root cause
The CRAG retry loop-back `<path>` used `fill="none"` (SVG presentation attribute), but the `.arrow-crag` CSS class set `fill: #b794f4`. In SVG, CSS class selectors override presentation attributes, so the path was filled purple — creating a triangle from the path coordinates.

## Fix
Changed `fill="none"` to `style="fill:none"` — inline styles have higher specificity than CSS class rules.

One-character fix: `fill=` → `style="fill:`.